### PR TITLE
More verifier cleanup and doc sync to 1.03 spec.

### DIFF
--- a/src/commonMain/kotlin/electionguard/ballot/EncryptedTally.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/EncryptedTally.kt
@@ -23,6 +23,7 @@ data class EncryptedTally(
     /**
      * The homomorphic accumulation of all of the CiphertextBallot.Selection for a specific
      * selection and contest. The selectionId is the Manifest.SelectionDescription.object_id.
+     * @param ciphertext The encrypted vote count = (A, B).
      */
     data class Selection(
         val selectionId: String,

--- a/src/commonMain/kotlin/electionguard/ballot/PlaintextTally.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/PlaintextTally.kt
@@ -4,12 +4,18 @@ import electionguard.core.ElGamalCiphertext
 import electionguard.core.ElementModP
 import electionguard.decrypt.PartialDecryption
 
+/**
+ * The decrypted counts of all contests in the election.
+ *
+ * @param tallyId the name of the tally. Matches ballotId when its a spoiled ballot decryption.
+ * @param contests The contests, keyed by contest.contestId.
+ */
 data class PlaintextTally(val tallyId: String, val contests: Map<String, Contest>) {
     /**
-     * The plaintext representation of the counts of one contest in the election.
+     * The decrypted counts of one contest in the election.
      *
      * @param contestId equals the Manifest.ContestDescription.contestId.
-     * @param selections The collection of selections in the contest, keyed by selection.object_id.
+     * @param selections The collection of selections in the contest, keyed by selection.selectionId.
      */
     data class Contest(
         val contestId: String, // matches ContestDescription.contestId
@@ -17,23 +23,23 @@ data class PlaintextTally(val tallyId: String, val contests: Map<String, Contest
     )
 
     /**
-     * The plaintext representation of the counts of one selection of one contest in the election.
+     * The decrypted count of one selection of one contest in the election.
      *
      * @param selectionId equals the Manifest.SelectionDescription.selectionId.
-     * @param tally the actual count.
+     * @param tally the decrypted vote count.
      * @param value g^tally or M in the spec.
-     * @param message The encrypted vote count.
+     * @param message The encrypted vote count = (A, B).
      * @param partialDecryptions The Guardians' shares of the decryption of a selection, nguardians of them.
      */
     data class Selection(
         val selectionId: String, // matches SelectionDescription.selectionId
         val tally: Int,
         val value: ElementModP,
-        val message: ElGamalCiphertext,
-        val partialDecryptions: List<PartialDecryption>,
+        val message: ElGamalCiphertext, // same as EncryptedTally.Selection.ciphertext
+        val partialDecryptions: List<PartialDecryption>, // one for each guardian
     )
 
-    fun showTallies() {
+    fun showTally() {
         println(" Tally $tallyId")
         contests.values.sortedBy { it.contestId }.forEach { contest ->
             println("  Contest ${contest.contestId}")

--- a/src/commonMain/kotlin/electionguard/core/ChaumPedersen.kt
+++ b/src/commonMain/kotlin/electionguard/core/ChaumPedersen.kt
@@ -5,9 +5,6 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getAllErrors
 
-import mu.KotlinLogging
-private val logger = KotlinLogging.logger("ChaumPedersen")
-
 /** Proof that the ciphertext is a given constant. */
 data class ConstantChaumPedersenProofKnownNonce(
     val proof: GenericChaumPedersenProof,
@@ -45,7 +42,7 @@ data class GenericChaumPedersenProof(val c: ElementModQ, val r: ElementModQ)
  * Expanded form of the [GenericChaumPedersenProof], with the `a` and `b` values recomputed. This
  * should not be serialized.
  */
-internal data class ExpandedGenericChaumPedersenProof(
+data class ExpandedGenericChaumPedersenProof(
     val a: ElementModP,
     val b: ElementModP,
     val c: ElementModQ,
@@ -56,7 +53,7 @@ internal data class ExpandedGenericChaumPedersenProof(
  * Given a [GenericChaumPedersenProof], computes the `a` and `b` values that are needed for proofs
  * and such, but are removed for serialization.
  */
-internal fun GenericChaumPedersenProof.expand(
+fun GenericChaumPedersenProof.expand(
     g: ElementModP,
     gx: ElementModP,
     h: ElementModP,
@@ -375,7 +372,7 @@ internal fun ExpandedGenericChaumPedersenProof.isValid(
     val inBoundsHx = hx.isValidResidue()
 
     if (!(inBoundsG && inBoundsGx && inBoundsH && inBoundsHx)) {
-        errors.add("  4.A invalid residual: " +
+        errors.add("  Invalid residual: " +
                 mapOf(
                     "inBoundsG" to inBoundsG,
                     "inBoundsGx" to inBoundsGx,
@@ -386,7 +383,7 @@ internal fun ExpandedGenericChaumPedersenProof.isValid(
 
     val hashGood = !checkC || c == hashElements(*hashHeader, a, b, *hashFooter).toElementModQ(context)
     if (!hashGood) {
-        errors.add("  4.B invalid challenge ")
+        errors.add("  Invalid challenge ")
     }
 
     return if (errors.isEmpty()) Ok(true) else Err(errors.joinToString("\n"))

--- a/src/commonMain/kotlin/electionguard/decrypt/DecryptingMediator.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/DecryptingMediator.kt
@@ -46,7 +46,7 @@ class DecryptingMediator(
         // now rearrange for use by Decryptor
         val sharesBySelectionId: MutableMap<String, MutableList<PartialDecryption>> = HashMap()
         for (tallyShare in shares) {
-            tallyShare.partialDecryptions.entries.map { (selectionId, partial) ->
+            tallyShare.directDecryptions.entries.map { (selectionId, partial) ->
                 var smap: MutableList<PartialDecryption>? = sharesBySelectionId[selectionId]
                 if (smap == null) {
                     smap = mutableListOf()
@@ -106,7 +106,7 @@ class DecryptingMediator(
 
         // direct decryptions
         val partialDecryptions: List<DirectDecryptionAndProof> =
-            trustee.partialDecrypt(group, texts, init.cryptoExtendedBaseHash(), null)
+            trustee.directDecrypt(group, texts, init.cryptoExtendedBaseHash(), null)
 
         // Place the results into the DecryptionShare
         val decryptionShare = DecryptionShare(trustee.id())
@@ -120,7 +120,7 @@ class DecryptingMediator(
                     proof.partialDecryption,
                     proof.proof,
                 )
-                decryptionShare.addPartialDecryption(
+                decryptionShare.addDirectDecryption(
                     tallyContest.contestId,
                     tallySelection.selectionId,
                     partialDecryption

--- a/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeIF.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeIF.kt
@@ -17,14 +17,14 @@ interface DecryptingTrusteeIF {
     fun electionPublicKey(): ElementModP
 
     /**
-     * Compute a partial decryption of an elgamal encryption.
+     * Compute a direct partial decryption of an elgamal encryption.
      *
      * @param texts:            list of `ElGamalCiphertext` that will be partially decrypted
      * @param extendedBaseHash: the extended base hash of the election
      * @param nonce:            an optional nonce to generate the `ChaumPedersenProof`
      * @return a list of DirectDecryptionAndProof, in the same order as the texts
      */
-    fun partialDecrypt(
+    fun directDecrypt(
         group: GroupContext,
         texts: List<ElGamalCiphertext>,
         extendedBaseHash: ElementModQ,

--- a/src/commonMain/kotlin/electionguard/decrypt/TallyDecryptor.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/TallyDecryptor.kt
@@ -48,9 +48,9 @@ class TallyDecryptor(val group: GroupContext, val jointPublicKey: ElGamalPublicK
         val decryptionShares: Iterable<ElementModP> = shares.map { it.share() }
         val allSharesProductM: ElementModP = with (group) { decryptionShares.multP() }
 
-        // Calculate 𝑀 = 𝐵⁄(∏𝑀𝑖) mod 𝑝. (spec section 3.5.1 eq 10)
+        // Calculate 𝑀 = 𝐵⁄(∏𝑀𝑖) mod 𝑝. (spec 1.03 section 3.5.1 eq 55)
         val decryptedValue: ElementModP = selection.ciphertext.data / allSharesProductM
-        // Calculate 𝑀 = K^t mod 𝑝. (spec section 3.5.1 eq 10b)
+        // Now we know M, and since 𝑀 = K^t mod 𝑝, t = logK (M) (note version 1 has 𝑀 = g^t)
         val dlogM: Int = jointPublicKey.dLog(decryptedValue, maxDlog)?: throw RuntimeException("dlog failed")
 
         return PlaintextTally.Selection(

--- a/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
+++ b/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
@@ -64,7 +64,7 @@ class KeyCeremonyTrustee(
         return Ok(publicKeys)
     }
 
-    // TODO this needs to be encrypted, see p10 spec 1.0
+    // TODO this needs to be encrypted, see spec 1.03 p 13, eq 13-16
     fun sendSecretKeyShare(otherGuardian: String): Result<SecretKeyShare, String> {
         if (mySecretKeyShares.containsKey(otherGuardian)) {
             return Ok(mySecretKeyShares[otherGuardian]!!)

--- a/src/commonMain/kotlin/electionguard/verifier/VerifyAggregation.kt
+++ b/src/commonMain/kotlin/electionguard/verifier/VerifyAggregation.kt
@@ -9,6 +9,14 @@ import electionguard.core.ElGamalCiphertext
 import electionguard.core.GroupContext
 import electionguard.core.plus
 
+/**
+ * Verification 7 (Correctness of ballot aggregation)
+ * An election verifier must confirm for each (non-placeholder) option in each contest in the election
+ * manifest that the aggregate encryption (A, B) satisfies
+ * (7.A) A = Prod(αj) mod p,
+ * (7.B) B = Prod(βj) mod p,
+ * where the (αj, βj ) are the corresponding encryptions on all cast ballots in the election record.
+ */
 class VerifyAggregation(
     val group: GroupContext,
     val aggregator: SelectionAggregator,
@@ -25,9 +33,8 @@ class VerifyAggregation(
                 val key: String = contest.contestId + "." + selection.selectionId
                 aggregator.get(key)
 
+                // Already did the accumulation, just have to verify it.
                 val accum = aggregator.get(key)
-
-                // its possible no ballots voted on this
                 if (accum != null) {
                     if (selection.ciphertext != accum) {
                         errors.add("    Ballot Aggregation does not match $key")

--- a/src/commonMain/kotlin/electionguard/verifier/VerifyRecoveredShares.kt
+++ b/src/commonMain/kotlin/electionguard/verifier/VerifyRecoveredShares.kt
@@ -12,6 +12,7 @@ import electionguard.core.GroupContext
 import electionguard.decrypt.PartialDecryption
 import electionguard.decrypt.computeLagrangeCoefficient
 
+/** When there are missing guardians, check "replacement partial decryptions" (box 10). */
 class VerifyRecoveredShares(
     val group: GroupContext,
     val decryptionResult: DecryptionResult
@@ -75,6 +76,7 @@ class VerifyRecoveredShares(
     // 10.B Confirm the correct missing tally share for each (non-placeholder) option
     // in each contest in the ballot coding file for each missing trustee T_i as
     //    M_i = ∏ l∈U (M_i,l)^w_l mod p
+    // guardian i is missing, l is available
     private fun verify10B(partial: PartialDecryption): Boolean {
         var product: ElementModP = group.ONE_MOD_P
         for (compShare in partial.recoveredDecryptions) {
@@ -85,7 +87,7 @@ class VerifyRecoveredShares(
             product = product * term
         }
 
-        val M_i: ElementModP = partial.share() // M_i in the spec, i is missing
+        val M_i: ElementModP = partial.share()
         return M_i.equals(product)
     }
 }

--- a/src/commonMain/proto/plaintext_tally.proto
+++ b/src/commonMain/proto/plaintext_tally.proto
@@ -43,10 +43,10 @@ message RecoveredParts {
 }
 
 message RecoveredPartialDecryption {
-  string selection_id = 1; // matches SelectionDescription.selection_id, version 1 only
+  reserved 1;
   string decrypting_guardian_id = 2;  // The Available Guardian that this share belongs to
   string missing_guardian_id = 3; //  // The Missing Guardian for whom this share is calculated on behalf of.
   ElementModP share = 4; // The Share of the decryption of a selection. M_il in the spec.
-  ElementModP recovery_key = 5; // The Public Key for the missing_guardian that corresponds to the available guardian's share of the secret.
+  ElementModP recovery_key = 5; // g^Pi(ℓ), where Pi(ℓ) is the value of the missing_guardian i secret polynomial at available guardian ℓ coordinate.
   GenericChaumPedersenProof proof = 6; // The Proof that the share was decrypted correctly.
 }


### PR DESCRIPTION
ExpandedGenericChaumPedersenProof needs to be public for access by the verifier.
Rename DecryptingTrustee.partialDecrypt to directDecrypt.
Rename DecryptionShare.partialDecryptions to directDecryptions.
Remove RecoveredPartialDecryption.selection_id from proto.