### PR TITLE
Factor out g^Pi(l)

### DIFF
--- a/src/commonMain/kotlin/electionguard/core/HashedElGamal.kt
+++ b/src/commonMain/kotlin/electionguard/core/HashedElGamal.kt
@@ -11,7 +11,29 @@ data class HashedElGamalCiphertext(
     val c1: ByteArray,
     val c2: UInt256,
     val numBytes: Int
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as HashedElGamalCiphertext
+
+        if (c0 != other.c0) return false
+        if (!c1.contentEquals(other.c1)) return false
+        if (c2 != other.c2) return false
+        if (numBytes != other.numBytes) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = c0.hashCode()
+        result = 31 * result + c1.contentHashCode()
+        result = 31 * result + c2.hashCode()
+        result = 31 * result + numBytes
+        return result
+    }
+}
 
 /**
  * Given an array of plaintext bytes, encrypts those bytes using the "hashed ElGamal" stream cipher,

--- a/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
+++ b/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
@@ -41,7 +41,7 @@ data class PublicKeys(
  * @param generatingGuardianId The Id of the guardian that generated this, who might be missing at decryption
  * @param designatedGuardianId The Id of the guardian to receive this backup, matches the DecryptingTrustee.id
  * @param designatedGuardianXCoordinate The x coordinate of the designated guardian
- * @param encryptedCoordinate Encryption of  generatingGuardian's polynomial value at designatedGuardianXCoordinate, El(P𝑖_{l})
+ * @param encryptedCoordinate Encryption of generatingGuardian's polynomial value at designatedGuardianXCoordinate, El(P𝑖_{l})
  */
 data class SecretKeyShare(
     val generatingGuardianId: String,


### PR DESCRIPTION
Factor out calculateGexpPiAtL() method from DecryptingTrustee and KeyCeremonyTrustee - duplicate code.

In DecryptingTrustee, calculate gPil lazily and outside of the ciphertext loop.
HashedElGamalCiphertext needs equals/hashCode because of ByteArray