### PR TITLE
Enable KeyCeremony remote processing.

### DIFF
--- a/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrustee.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrustee.kt
@@ -22,7 +22,10 @@ import mu.KotlinLogging
 private val logger = KotlinLogging.logger("DecryptingTrustee")
 private const val validate = true // expensive, debugging only
 
-/** A Trustee that knows its own secret key, for the purpose of decryption. */
+/**
+ * A Trustee that knows its own secret key, for the purpose of decryption.
+ * DecryptingTrustee must stay private. DecryptingGuardian is its public info in the election record.
+ */
 data class DecryptingTrustee(
     val id: String,
     val xCoordinate: Int,

--- a/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeIF.kt
+++ b/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeIF.kt
@@ -1,0 +1,20 @@
+package electionguard.keyceremony
+
+import com.github.michaelbull.result.Result
+import electionguard.core.ElementModP
+
+interface KeyCeremonyTrusteeIF {
+    fun id(): String
+    fun xCoordinate(): Int
+    fun electionPublicKey(): ElementModP
+    fun coefficientCommitments(): List<ElementModP>
+
+    /** Send my PublicKeys. */
+    fun sendPublicKeys(): Result<PublicKeys, String>
+    /** Receive the PublicKeys from another guardian. */
+    fun receivePublicKeys(publicKeys: PublicKeys): Result<PublicKeys, String>
+    /** Create my SecretKeyShare for another guardian. */
+    fun sendSecretKeyShare(otherGuardian: String): Result<SecretKeyShare, String>
+    /** Receive and verify another guardian's SecretKeyShare for me. */
+    fun receiveSecretKeyShare(share: SecretKeyShare): Result<SecretKeyShare, String>
+}

--- a/src/commonTest/kotlin/electionguard/workflow/FakeKeyCeremonyTest.kt
+++ b/src/commonTest/kotlin/electionguard/workflow/FakeKeyCeremonyTest.kt
@@ -2,6 +2,7 @@ package electionguard.workflow
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.unwrap
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.Guardian
@@ -26,6 +27,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /** Run a fake KeyCeremony to generate an ElectionInitialized for workflow testing. */
+// LOOK can we call RunKeyCeremony instead?
 class RunFakeKeyCeremonyTest {
 
     @Test
@@ -80,7 +82,7 @@ fun runFakeKeyCeremony(
     }
 
     val commitments: MutableList<ElementModP> = mutableListOf()
-    trustees.forEach { commitments.addAll(it.polynomial.coefficientCommitments) }
+    trustees.forEach { commitments.addAll(it.coefficientCommitments()) }
     val commitmentsHash = hashElements(commitments)
 
     val primes = config.constants
@@ -129,7 +131,7 @@ fun runFakeKeyCeremony(
 }
 
 fun makeGuardian(trustee: KeyCeremonyTrustee): Guardian {
-    val publicKeys = trustee.sharePublicKeys()
+    val publicKeys = trustee.sendPublicKeys().unwrap()
     return Guardian(
         trustee.id,
         trustee.xCoordinate,
@@ -148,7 +150,7 @@ fun makeDecryptingTrustee(ktrustee: KeyCeremonyTrustee): DecryptingTrustee {
         ktrustee.id,
         ktrustee.xCoordinate,
         ElGamalKeypair(
-            ElGamalSecretKey(ktrustee.polynomial.coefficients[0]),
+            ElGamalSecretKey(ktrustee.electionPrivateKey()),
             ElGamalPublicKey(ktrustee.electionPublicKey())
         ),
         ktrustee.guardianSecretKeyShares,

--- a/src/commonTest/kotlin/electionguard/workflow/RecoveredDecryptionTest.kt
+++ b/src/commonTest/kotlin/electionguard/workflow/RecoveredDecryptionTest.kt
@@ -1,6 +1,7 @@
 package electionguard.workflow
 
 import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.unwrap
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.Guardian
@@ -26,7 +27,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /** Test KeyCeremony Trustee generation and recovered decryption. */
-
+// LOOK can we call RunKeyCeremony instead?
 class RecoveredDecryptionTest {
     @Test
     fun runFakeKeyCeremonyTrusteeTest() {
@@ -62,14 +63,14 @@ fun runRecoveredDecryptionTest(
     // exchange PublicKeys
     trustees.forEach { t1 ->
         trustees.forEach { t2 ->
-            t1.receivePublicKeys(t2.sharePublicKeys())
+            t1.receivePublicKeys(t2.sendPublicKeys().unwrap())
         }
     }
 
     // exchange SecretKeyShares
     trustees.forEach { t1 ->
         trustees.forEach { t2 ->
-            t2.receiveSecretKeyShare(t1.sendSecretKeyShare(t2.id))
+            t2.receiveSecretKeyShare(t1.sendSecretKeyShare(t2.id).unwrap())
         }
     }
 
@@ -83,7 +84,7 @@ fun runRecoveredDecryptionTest(
     //////////////////////////////////////////////////////////
     if (writeout) {
         val commitments: MutableList<ElementModP> = mutableListOf()
-        trustees.forEach { commitments.addAll(it.polynomial.coefficientCommitments) }
+        trustees.forEach { commitments.addAll(it.coefficientCommitments()) }
         val commitmentsHash = hashElements(commitments)
 
         val consumerIn = Consumer(configDir, group)

--- a/src/jvmMain/kotlin/electionguard/core/UtilsKmm.kt
+++ b/src/jvmMain/kotlin/electionguard/core/UtilsKmm.kt
@@ -1,11 +1,10 @@
 package electionguard.core
 
-import io.ktor.util.date.*
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 
-actual fun getSystemTimeInMillis() : Long = getTimeMillis()
+actual fun getSystemTimeInMillis() : Long = System.currentTimeMillis()
 
 actual fun fileExists(filename: String): Boolean = Files.exists(Path.of(filename))
 

--- a/src/jvmMain/kotlin/electionguard/publish/Publisher.kt
+++ b/src/jvmMain/kotlin/electionguard/publish/Publisher.kt
@@ -16,7 +16,6 @@ import electionguard.publish.ElectionRecordPath.Companion.ELECTION_INITIALIZED_F
 import electionguard.publish.ElectionRecordPath.Companion.SPOILED_BALLOT_FILE
 import electionguard.publish.ElectionRecordPath.Companion.ENCRYPTED_BALLOT_PROTO
 import electionguard.publish.ElectionRecordPath.Companion.TALLY_RESULT_NAME
-import io.ktor.utils.io.errors.*
 import pbandk.encodeToStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -48,7 +47,6 @@ actual class Publisher actual constructor(topDir: String, publisherMode: Publish
     }
 
     /** Delete everything in the given directory, but leave that directory.  */
-    @Throws(IOException::class)
     private fun removeAllFiles(path: Path) {
         if (!path.toFile().exists()) {
             return
@@ -151,7 +149,6 @@ actual class Publisher actual constructor(topDir: String, publisherMode: Publish
         }
     }
 
-    @Throws(IOException::class)
     actual fun writePlaintextBallot(outputDir: String, plaintextBallots: List<PlaintextBallot>) {
         if (!plaintextBallots.isEmpty()) {
             val fileout = path.plaintextBallotPath(outputDir)


### PR DESCRIPTION
Make KeyCeremonyTrusteeIF, clarify the API.
Add parameter checking on KeyCeremony classes.
Remove use of io.ktor in the JVM, not needed.