### PR TITLE
KeyCeremonyTrusteeIF.checkComplete() to make sure number of shares is correct.

### DIFF
--- a/egklib/src/commonMain/kotlin/electionguard/json2/TrusteeJson.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/json2/TrusteeJson.kt
@@ -20,7 +20,7 @@ fun KeyCeremonyTrustee.publishJson(): TrusteeJson {
         this.id,
         this.xCoordinate,
         this.polynomial.coefficients.map { it.publishJson() },
-        this.secretKeyShare().publishJson(),
+        this.computeSecretKeyShare().publishJson(),
     )
 }
 

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
@@ -115,12 +115,11 @@ fun keyCeremonyExchange(trustees: List<KeyCeremonyTrusteeIF>, allowEncryptedFail
         }
     }
 
-    // at this point we do the computeSecretKeyShare and see if there are errors
-    val results : List<Result<ElementModQ, String>> = trustees.map { it.computeSecretKeyShare(trustees.size) }
-    val (_, shareErrors)  = results.partition()
-    //if (shareErrors.isNotEmpty()) {
-    //    Err("keyCeremonyExchange failed exchanging shares:\n ${shareErrors.merge()}")
-    //}
+    // check that everyone is happy
+    var happy = trustees.map { it.checkComplete() }.reduce{ a, b -> a && b }
+    if (!happy) {
+        return Err("keyCeremonyExchange failed checkComplete")
+    }
 
     if (allowEncryptedFailure) {
         val keyResultAll = keyResults.merge()

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeIF.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeIF.kt
@@ -2,7 +2,6 @@ package electionguard.keyceremony
 
 import com.github.michaelbull.result.Result
 import electionguard.core.ElementModP
-import electionguard.core.ElementModQ
 import electionguard.core.SchnorrProof
 
 interface KeyCeremonyTrusteeIF {
@@ -27,9 +26,6 @@ interface KeyCeremonyTrusteeIF {
     /** Receive and verify a key share. */
     fun receiveKeyShare(keyShare: KeyShare): Result<Boolean, String>
 
-    /** call after all shares are added, and before calling secretKeyShare() */
-    fun computeSecretKeyShare(nguardians : Int): Result<ElementModQ, String>
-
-    /** The resulting secretKeyShare for this guardian == (P1(ℓ) + P2(ℓ) + · · · + Pn(ℓ)) mod q. spec 2.0.0, eq 65. */
-    fun secretKeyShare(): ElementModQ
+    /** call after all shares are added */
+    fun checkComplete(): Boolean
 }

--- a/egklib/src/commonMain/kotlin/electionguard/protoconvert/DecryptingTrusteeProto.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/protoconvert/DecryptingTrusteeProto.kt
@@ -57,7 +57,7 @@ fun KeyCeremonyTrustee.publishDecryptingTrusteeProto() =
         this.id(),
         this.xCoordinate(),
         this.electionPublicKey().publishProto(),
-        this.secretKeyShare().publishProto(),
+        this.computeSecretKeyShare().publishProto(),
     )
 
 private fun EncryptedKeyShare.publishProto() =

--- a/egklib/src/commonTest/kotlin/electionguard/ballot/BallotTestUtils.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/ballot/BallotTestUtils.kt
@@ -10,7 +10,7 @@ fun makeDoerreTrustee(ktrustee: KeyCeremonyTrustee): DecryptingTrusteeDoerre {
         ktrustee.id,
         ktrustee.xCoordinate,
         ktrustee.electionPublicKey(),
-        ktrustee.secretKeyShare(),
+        ktrustee.computeSecretKeyShare(),
     )
 }
 

--- a/egklib/src/commonTest/kotlin/electionguard/decrypt/DoerreTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decrypt/DoerreTest.kt
@@ -37,7 +37,7 @@ fun runDoerreTest(
 ) {
     val trustees: List<KeyCeremonyTrustee> = List(nguardians) {
         val seq = it + 1
-        KeyCeremonyTrustee(group,"guardian$seq", seq, quorum)
+        KeyCeremonyTrustee(group,"guardian$seq", seq, nguardians, quorum)
     }.sortedBy { it.xCoordinate }
 
     // exchange PublicKeys
@@ -53,7 +53,7 @@ fun runDoerreTest(
             t2.receiveEncryptedKeyShare(t1.encryptedKeyShareFor(t2.id).unwrap())
         }
     }
-    trustees.forEach { it.computeSecretKeyShare(nguardians) }
+    trustees.forEach { it.checkComplete() }
 
     val dTrustees: List<DecryptingTrusteeDoerre> = trustees.map { makeDoerreTrustee(it) }
 

--- a/egklib/src/commonTest/kotlin/electionguard/decrypt/LagrangeTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decrypt/LagrangeTest.kt
@@ -54,11 +54,11 @@ class LagrangeTest {
         val w1 = group.computeLagrangeCoefficient(1, listOf(1, 2))
         val w2 = group.computeLagrangeCoefficient(2, listOf(1, 2))
 
-        val polly1 = KeyCeremonyTrustee(group, "guardian1", 1, 2)
+        val polly1 = KeyCeremonyTrustee(group, "guardian1", 1, 2, 2)
         val y11 = polly1.valueAt(group, 1)
         val y12 = polly1.valueAt(group, 2)
 
-        val polly2 = KeyCeremonyTrustee(group, "guardian2", 2, 2)
+        val polly2 = KeyCeremonyTrustee(group, "guardian2", 2, 2, 2)
         val y21 = polly2.valueAt(group, 1)
         val y22 = polly2.valueAt(group, 2)
 
@@ -72,11 +72,11 @@ class LagrangeTest {
         val w1 = group.computeLagrangeCoefficient(1, listOf(1, 2))
         val w2 = group.computeLagrangeCoefficient(2, listOf(1, 2))
 
-        val polly1 = KeyCeremonyTrustee(group, "guardian1", 1, 2)
+        val polly1 = KeyCeremonyTrustee(group, "guardian1", 1, 2, 2)
         val y11 = polly1.valueAt(group, 1)
         val y12 = polly1.valueAt(group, 2)
 
-        val polly2 = KeyCeremonyTrustee(group, "guardian2", 2, 2)
+        val polly2 = KeyCeremonyTrustee(group, "guardian2", 2, 2, 2)
         val y21 = polly2.valueAt(group, 1)
         val y22 = polly2.valueAt(group, 2)
 
@@ -95,15 +95,11 @@ class LagrangeTest {
                 t2.receiveEncryptedKeyShare(t1.encryptedKeyShareFor(t2.id).unwrap())
             }
         }
-
-        // compute SecretKeyShares
-        trustees.forEach { it.computeSecretKeyShare(2) }
-
-        assertEquals(y11 + y21, polly1.secretKeyShare())
-        assertEquals(y12 + y22, polly2.secretKeyShare())
+        assertEquals(y11 + y21, polly1.computeSecretKeyShare())
+        assertEquals(y12 + y22, polly2.computeSecretKeyShare())
 
         val expected = polly1.electionPrivateKey() + polly2.electionPrivateKey()
-        val computed = polly1.secretKeyShare() * w1 + polly2.secretKeyShare() * w2
+        val computed = polly1.computeSecretKeyShare() * w1 + polly2.computeSecretKeyShare() * w2
         assertEquals(expected, computed)
 
         testKeyShares(group, trustees, listOf(1, 2))
@@ -118,16 +114,16 @@ class LagrangeTest {
 
         val weightedSum = with(group) {
             trustees.map {
-                assertTrue( it.secretKeyShare().inBounds())
+                assertTrue( it.computeSecretKeyShare().inBounds())
                 val coeff = lagrangeCoefficients[it.id] ?: throw IllegalArgumentException()
-                it.secretKeyShare() * coeff
+                it.computeSecretKeyShare() * coeff
             }.addQ() // eq 7
         }
 
         var weightedSum2 = group.ZERO_MOD_Q
         trustees.forEach {
             val coeff = lagrangeCoefficients[it.id] ?: throw IllegalArgumentException()
-            weightedSum2 += it.secretKeyShare() * coeff
+            weightedSum2 += it.computeSecretKeyShare() * coeff
         }
         assertEquals(weightedSum, weightedSum2)
 

--- a/egklib/src/commonTest/kotlin/electionguard/decryptBallot/EncryptDecryptBallotTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decryptBallot/EncryptDecryptBallotTest.kt
@@ -70,7 +70,7 @@ fun runEncryptDecryptBallot(
     //// simulate key ceremony
     val trustees: List<KeyCeremonyTrustee> = List(nguardians) {
         val seq = it + 1
-        KeyCeremonyTrustee(group, "guardian$seq", seq, quorum)
+        KeyCeremonyTrustee(group, "guardian$seq", seq, nguardians, quorum)
     }.sortedBy { it.xCoordinate }
     trustees.forEach { t1 ->
         trustees.forEach { t2 ->
@@ -82,9 +82,6 @@ fun runEncryptDecryptBallot(
             t2.receiveEncryptedKeyShare(t1.encryptedKeyShareFor(t2.id).unwrap())
         }
     }
-    // compute SecretKeyShares
-    trustees.forEach { it.computeSecretKeyShare(nguardians) }
-
     val dTrustees: List<DecryptingTrusteeDoerre> = trustees.map { makeDoerreTrustee(it) }
     val guardianList: List<Guardian> = trustees.map { makeGuardian(it) }
     val guardians = Guardians(group, guardianList)

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTest.kt
@@ -12,15 +12,14 @@ import kotlin.test.assertTrue
 
 class KeyCeremonyTest {
 
-
     @Test
     fun testKeyCeremony() {
         val nguardians = 3
         val quorum = 2
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, quorum)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, quorum)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, quorum)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, nguardians, quorum)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, nguardians, quorum)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, nguardians, quorum)
         val trustees = listOf(trustee1, trustee2, trustee3)
 
         val result = keyCeremonyExchange(trustees)
@@ -33,7 +32,7 @@ class KeyCeremonyTest {
         assertEquals(expected, keys)
 
         trustees.forEach {
-            assertEquals(2, it.otherPublicKeys.size)
+            assertTrue(it.checkComplete())
         }
 
         val config = makeElectionConfig(
@@ -70,9 +69,9 @@ class KeyCeremonyTest {
     @Test
     fun testKeyCeremonyFailQuorum() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 2)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3, 2)
         val trustees = listOf(trustee1, trustee2, trustee3)
 
         val result = keyCeremonyExchange(trustees)
@@ -84,9 +83,9 @@ class KeyCeremonyTest {
     @Test
     fun testKeyCeremonyFailTrusteeIdDuplicate() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id1", 2, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id1", 2, 3, 3)
         val trustees = listOf(trustee1, trustee2, trustee3)
 
         val result = keyCeremonyExchange(trustees)
@@ -98,9 +97,9 @@ class KeyCeremonyTest {
     @Test
     fun testKeyCeremonyFailTrusteeCoordDuplicate() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 3, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 3, 3, 3)
         val trustees = listOf(trustee1, trustee2, trustee3)
 
         val result = keyCeremonyExchange(trustees)

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeTest.kt
@@ -12,7 +12,7 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testPublicKeys() {
         val group = productionGroup()
-        val trustee = KeyCeremonyTrustee(group, "id", 42, 4)
+        val trustee = KeyCeremonyTrustee(group, "id", 42, 4, 4)
         assertEquals("id", trustee.id())
         assertEquals(42, trustee.xCoordinate())
         assertNotNull(trustee.electionPublicKey())
@@ -32,8 +32,8 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testReceivePublicKeysBadQuorum() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 5)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 5, 5)
 
         val result1 = trustee1.receivePublicKeys(trustee2.publicKeys().unwrap())
         assertTrue(result1 is Err)
@@ -43,7 +43,7 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testReceivePublicKeysBadReceiver() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
         val result1 = trustee1.receivePublicKeys(trustee1.publicKeys().unwrap())
         assertTrue(result1 is Err)
         assertEquals("Cant send 'id1' public keys to itself", result1.error)
@@ -52,7 +52,7 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testReceivePublicKeysBadProofs() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
         val goodProof = trustee1.coefficientProofs()[0]
         val badProof = goodProof.copy(challenge = group.TWO_MOD_Q)
         val badProofs = trustee1.coefficientProofs().toMutableList()
@@ -67,8 +67,8 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testShareEncryptDecrypt() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 4)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 5, 4)
 
         val publicKeys2 : PublicKeys = trustee2.publicKeys().unwrap()
         val pil = group.randomElementModQ()
@@ -84,8 +84,8 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testReceiveSecretKeyShare() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 4)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 5, 4)
 
         val result1 = trustee1.receivePublicKeys(trustee2.publicKeys().unwrap())
         assertTrue(result1 is Ok)
@@ -117,8 +117,8 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testValidateSecretKeyShare() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 4)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 5, 4)
 
         assertTrue(trustee1.receivePublicKeys(trustee2.publicKeys().unwrap()) is Ok)
         assertTrue(trustee2.receivePublicKeys(trustee1.publicKeys().unwrap()) is Ok)
@@ -144,7 +144,7 @@ class KeyCeremonyTrusteeTest {
         assertEquals("Trustee 'id1' couldnt decrypt EncryptedKeyShare for missingGuardianId 'id2'", result5.error)
 
         // mess this one up so it wont validate
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 43, 4)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 43, 5, 4)
         assertTrue(trustee1.receivePublicKeys(trustee3.publicKeys().unwrap()) is Ok)
         // give it the wrong generatingGuardianId
         val ss2v1 = ss21.copy(polynomialOwner = "id3")
@@ -156,8 +156,8 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testKeyShareFor() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 4)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 5, 4)
 
         assertTrue(trustee1.receivePublicKeys(trustee2.publicKeys().unwrap()) is Ok)
         assertTrue(trustee2.receivePublicKeys(trustee1.publicKeys().unwrap()) is Ok)
@@ -182,8 +182,8 @@ class KeyCeremonyTrusteeTest {
     @Test
     fun testReceiveKeyShare() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 4)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 5, 4)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 42, 5, 4)
 
         assertTrue(trustee1.receivePublicKeys(trustee2.publicKeys().unwrap()) is Ok)
         assertTrue(trustee2.receivePublicKeys(trustee1.publicKeys().unwrap()) is Ok)

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/ShareEncryptDecryptTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/ShareEncryptDecryptTest.kt
@@ -19,8 +19,8 @@ class ShareEncryptDecryptTest {
                 Arb.int(min=1, max=100),
                 elementsModQ(group, minimum = 2)
             ) { xcoord, pil ->
-                val trustee1 = KeyCeremonyTrustee(group, "id1", xcoord, 4)
-                val trustee2 = KeyCeremonyTrustee(group, "id2", xcoord+1, 4)
+                val trustee1 = KeyCeremonyTrustee(group, "id1", xcoord, 4, 4)
+                val trustee2 = KeyCeremonyTrustee(group, "id2", xcoord+1, 4, 4)
 
                 val publicKeys2 : PublicKeys = trustee2.publicKeys().unwrap()
                 val share : HashedElGamalCiphertext = trustee1.shareEncryption(pil, publicKeys2)

--- a/egklib/src/commonTest/kotlin/electionguard/workflow/FakeKeyCeremonyTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/workflow/FakeKeyCeremonyTest.kt
@@ -12,6 +12,7 @@ import electionguard.publish.makePublisher
 import electionguard.publish.readElectionRecord
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /** Run a fake KeyCeremony to generate an ElectionInitialized for workflow testing. */
 class RunFakeKeyCeremonyTest {
@@ -51,7 +52,7 @@ fun runFakeKeyCeremony(
 
     val trustees: List<KeyCeremonyTrustee> = List(nguardians) {
         val seq = it + 1
-        KeyCeremonyTrustee(group, "guardian$seq", seq, quorum)
+        KeyCeremonyTrustee(group, "guardian$seq", seq, nguardians, quorum)
     }.sortedBy { it.xCoordinate }
 
     // exchange PublicKeys
@@ -62,7 +63,7 @@ fun runFakeKeyCeremony(
 
     // check they are complete
     trustees.forEach {
-        assertEquals(nguardians - 1, it.otherPublicKeys.size)
+        assertTrue( it.checkComplete() )
         assertEquals(quorum, it.coefficientCommitments().size)
     }
 

--- a/egklib/src/jvmMain/kotlin/electionguard/cli/RunTrustedKeyCeremony.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/cli/RunTrustedKeyCeremony.kt
@@ -81,7 +81,7 @@ class RunTrustedKeyCeremony {
             // Generate all KeyCeremonyTrustees here, which means this is a trusted situation.
             val trustees: List<KeyCeremonyTrustee> = List(config.numberOfGuardians) {
                 val seq = it + 1
-                KeyCeremonyTrustee(group, "trustee$seq", seq, config.quorum)
+                KeyCeremonyTrustee(group, "trustee$seq", seq, nguardians = config.numberOfGuardians, quorum = config.quorum )
             }
 
             val exchangeResult = keyCeremonyExchange(trustees)

--- a/egklib/src/jvmTest/kotlin/electionguard/decrypt/MissingGuardianTests.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/decrypt/MissingGuardianTests.kt
@@ -41,7 +41,7 @@ class MissingGuardianTests {
 
         val trustees: List<KeyCeremonyTrustee> = List(nguardians) {
             val seq = it + 1
-            KeyCeremonyTrustee(group, "guardian$seq", seq, quorum)
+            KeyCeremonyTrustee(group, "guardian$seq", seq, nguardians, quorum)
         }.sortedBy { it.xCoordinate }
 
         // exchange PublicKeys
@@ -57,8 +57,7 @@ class MissingGuardianTests {
                 t2.receiveEncryptedKeyShare(t1.encryptedKeyShareFor(t2.id).unwrap())
             }
         }
-        // compute SecretKeyShares
-        trustees.forEach { it.computeSecretKeyShare(nguardians) }
+        trustees.forEach { it.checkComplete() }
 
         val dTrustees: List<DecryptingTrusteeDoerre> = trustees.map { makeDoerreTrustee(it) }
 

--- a/egklib/src/jvmTest/kotlin/electionguard/keyceremony/KeyCeremonyMockTest.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/keyceremony/KeyCeremonyMockTest.kt
@@ -15,9 +15,9 @@ class KeyCeremonyMockTest {
     @Test
     fun testKeyCeremonyOk() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3, 3)
         val spy3 = spyk(trustee3)
         val trustees = listOf(trustee1, trustee2, spy3)
 
@@ -28,9 +28,9 @@ class KeyCeremonyMockTest {
     @Test
     fun testKeyCeremonyMockOk() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3, 3)
         val spy3 = spyk(trustee3)
         every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
             val result1 = trustee3.encryptedKeyShareFor(trustee1.id())
@@ -47,9 +47,9 @@ class KeyCeremonyMockTest {
     @Test
     fun testAllowBadEncryptedShare() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3, 3)
         val spy3 = spyk(trustee3)
         every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
             trustee3.encryptedKeyShareFor(trustee1.id()) // trustee needs to cache
@@ -65,9 +65,9 @@ class KeyCeremonyMockTest {
     @Test
     fun testBadEncryptedShare() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3, 3)
         val spy3 = spyk(trustee3)
         every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
             trustee3.encryptedKeyShareFor(trustee1.id()) // trustee needs to cache
@@ -84,9 +84,9 @@ class KeyCeremonyMockTest {
     @Test
     fun testBadKeySharesAllowFalse() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3, 3)
         val spy3 = spyk(trustee3)
         every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
             trustee3.encryptedKeyShareFor(trustee1.id()) // trustee needs to cache
@@ -101,6 +101,7 @@ class KeyCeremonyMockTest {
         val result = keyCeremonyExchange(trustees, false)
         println("result = $result")
         assertTrue(result is Err)
+        println(result)
         assertTrue(result.error.contains("Trustee 'id1' couldnt decrypt EncryptedKeyShare for missingGuardianId 'id3'"))
         assertTrue(result.error.contains("Trustee 'id1' failed to validate KeyShare for missingGuardianId 'id3'"))
     }
@@ -108,9 +109,9 @@ class KeyCeremonyMockTest {
     @Test
     fun testBadKeySharesAllowTrue() {
         val group = productionGroup()
-        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
-        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
-        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3, 3)
         val spy3 = spyk(trustee3)
         every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
             trustee3.encryptedKeyShareFor(trustee1.id()) // trustee needs to cache
@@ -125,6 +126,7 @@ class KeyCeremonyMockTest {
         val result = keyCeremonyExchange(trustees, true)
         println("result = $result")
         assertTrue(result is Err)
+        println(result)
         assertTrue(result.error.contains("Trustee 'id1' couldnt decrypt EncryptedKeyShare for missingGuardianId 'id3'"))
         assertTrue(result.error.contains("Trustee 'id1' failed to validate KeyShare for missingGuardianId 'id3'"))
     }

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/DecryptBallotTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/DecryptBallotTestVector.kt
@@ -59,7 +59,7 @@ class DecryptBallotTestVector {
         // run the whole workflow
         val keyCeremonyTrustees: List<KeyCeremonyTrustee> = List(numberOfGuardians) {
             val seq = it + 1
-            KeyCeremonyTrustee(group, "guardian$seq", seq, quorum)
+            KeyCeremonyTrustee(group, "guardian$seq", seq, numberOfGuardians, quorum)
         }.sortedBy { it.xCoordinate }
 
         keyCeremonyExchange(keyCeremonyTrustees)
@@ -87,7 +87,7 @@ class DecryptBallotTestVector {
         }.first()
         val encryptedBallot = ciphertextBallot.submit(EncryptedBallot.BallotState.CAST)
 
-        val trusteesAll = keyCeremonyTrustees.map { DecryptingTrusteeDoerre(it.id, it.xCoordinate, it.electionPublicKey(), it.secretKeyShare()) }
+        val trusteesAll = keyCeremonyTrustees.map { DecryptingTrusteeDoerre(it.id, it.xCoordinate, it.electionPublicKey(), it.computeSecretKeyShare()) }
 
         val guardians = keyCeremonyTrustees.map { Guardian(it.id, it.xCoordinate, it.coefficientProofs()) }
         val guardiansWrapper = Guardians(group, guardians)
@@ -129,7 +129,7 @@ class DecryptBallotTestVector {
         val publicKey = ElGamalPublicKey(testVector.joint_public_key.import(group))
         val encryptedBallot = testVector.encrypted_ballot.import(group)
 
-        val keyCeremonyTrustees =  testVector.trustees.map { it.importKeyCeremonyTrustee(group) }
+        val keyCeremonyTrustees =  testVector.trustees.map { it.importKeyCeremonyTrustee(group, numberOfGuardians) }
         val trusteesAll = testVector.trustees.map { it.importDecryptingTrustee(group) }
         val guardians = keyCeremonyTrustees.map { Guardian(it.id, it.xCoordinate, it.coefficientProofs()) }
         val guardiansWrapper = Guardians(group, guardians)

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/TallyDecryptionTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/TallyDecryptionTestVector.kt
@@ -107,7 +107,7 @@ class TallyDecryptionTestVector(
         // run the whole workflow
         val keyCeremonyTrustees: List<KeyCeremonyTrustee> = List(numberOfGuardians) {
             val seq = it + 1
-            KeyCeremonyTrustee(group, "guardian$seq", seq, quorum)
+            KeyCeremonyTrustee(group, "guardian$seq", seq, numberOfGuardians, quorum)
         }.sortedBy { it.xCoordinate }
 
         keyCeremonyExchange(keyCeremonyTrustees)
@@ -140,7 +140,7 @@ class TallyDecryptionTestVector(
         }
         val encryptedTally = accumulator.build()
 
-        val trusteesAll = keyCeremonyTrustees.map { DecryptingTrusteeDoerre(it.id, it.xCoordinate, it.electionPublicKey(), it.secretKeyShare()) }
+        val trusteesAll = keyCeremonyTrustees.map { DecryptingTrusteeDoerre(it.id, it.xCoordinate, it.electionPublicKey(), it.computeSecretKeyShare()) }
         // leave out one of the trustees to make it a partial decryption
         val trusteesMinus1 = trusteesAll.filter { !missingCoordinates.contains(it.xCoordinate) }
 
@@ -183,7 +183,7 @@ class TallyDecryptionTestVector(
         val publicKey = ElGamalPublicKey(testVector.joint_public_key.import(group))
         val encryptedTally = testVector.encrypted_tally.import(group)
 
-        val keyCeremonyTrustees =  testVector.trustees.map { it.importKeyCeremonyTrustee(group) }
+        val keyCeremonyTrustees =  testVector.trustees.map { it.importKeyCeremonyTrustee(group, numberOfGuardians) }
         val trusteesAll = testVector.trustees.map { it.importDecryptingTrustee(group) }
         // leave out one of the trustees to make it a partial decryption
         val trusteesMinus1 = trusteesAll.filter { !missingCoordinates.contains(it.xCoordinate) }

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/TrusteeJson.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/TrusteeJson.kt
@@ -21,16 +21,17 @@ fun KeyCeremonyTrustee.publishJsonE(missing : Boolean): TrusteeJson {
         this.id,
         this.xCoordinate,
         this.polynomial.coefficients.map { it.publishJson() },
-        this.secretKeyShare().publishJson(),
+        this.computeSecretKeyShare().publishJson(),
         missing,
     )
 }
 
-fun TrusteeJson.importKeyCeremonyTrustee(group: GroupContext): KeyCeremonyTrustee {
+fun TrusteeJson.importKeyCeremonyTrustee(group: GroupContext, nguardians: Int): KeyCeremonyTrustee {
     return KeyCeremonyTrustee(
         group,
         this.id,
         this.xCoordinate,
+        nguardians,
         polynomial_coefficients.size,
         group.regeneratePolynomial(
             this.id,
@@ -41,7 +42,8 @@ fun TrusteeJson.importKeyCeremonyTrustee(group: GroupContext): KeyCeremonyTruste
 }
 
 fun TrusteeJson.importDecryptingTrustee(group: GroupContext): DecryptingTrusteeDoerre {
-    return DecryptingTrusteeDoerre(this.id,
+    return DecryptingTrusteeDoerre(
+        this.id,
         this.xCoordinate,
         group.gPowP(this.polynomial_coefficients[0].import(group)),
         this.keyShare.import(group))


### PR DESCRIPTION
Modify keyCeremonyExchange() to use checkComplete(). 
KeyCeremonyTrustee has "nguardians" field.
Add KeyCeremonyTrustee.computeSecretKeyShare(nguardians : Int): ElementModQ for serialization, not in KeyCeremonyTrusteeIF.