### PR TITLE
Use contestLimit and optionLimit in encryption and validation.

### DIFF
--- a/docs/InputValidation.md
+++ b/docs/InputValidation.md
@@ -1,5 +1,5 @@
 # 🗳 Input Validation
-_last changed: Sep 25, 2023_
+_last changed: Oct 3, 2023_
 
 The election manifest and each input plaintext ballot are expected to be validated before being passed to the 
 EKM library. 
@@ -55,11 +55,15 @@ For additional safety, Manifest Validation may be run during other workflow step
 
 1. A ContestDescription has VoteVariationType = n_of_m, one_of_m, or approval.
 
-2. A one_of_m contest has votes_allowed == 1.
+2. A one_of_m contest has contest_limit == 1.
 
-3. A n_of_m contest has 0 < votes_allowed <= number of selections in the contest. 
+3. A n_of_m contest has 0 < contest_limit <= number of selections in the contest. 
 
-4. An approval contest has votes_allowed == number of selections in the contest.
+4. An approval contest has contest_limit == number of selections in the contest.
+
+5. A contest contest_limit must be > 0.
+
+6. A contest option_limit must be > 0 and <= contest_limit.
 
 
 ## Input Ballot
@@ -96,6 +100,7 @@ If an Input Ballot fails validation, it is annotated as to why it failed, and pl
 
 ### C. Voting limits
 
-1. Each PlaintextBallot.Selection must have a vote whose value is 0 or 1.
+Voting limits are not enforced at ballot validation. They are marked as overvotes. So an overvote on one contest does not
+invalidate the entire ballot.
 
 

--- a/egklib/src/commonMain/kotlin/electionguard/ballot/ContestData.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/ballot/ContestData.kt
@@ -65,9 +65,9 @@ data class ContestData(
         contestId: String, // aka Λ
         contestIndex: Int, // ind_c(Λ)
         ballotNonce: UInt256,
-        votesAllowed: Int): HashedElGamalCiphertext {
+        contestLimit: Int): HashedElGamalCiphertext {
 
-        val messageSize = (1 + votesAllowed) * BLOCK_SIZE
+        val messageSize = (1 + contestLimit) * BLOCK_SIZE
 
         var trialContestData = this
         var trialContestDataBA = trialContestData.publish().encodeToByteArray()
@@ -76,8 +76,8 @@ data class ContestData(
         trialSizes.add(trialSize)
 
         // remove extra write_ins, append a "*"
-        if ((trialSize > messageSize) && trialContestData.writeIns.size > votesAllowed) {
-            val truncateWriteIns = trialContestData.writeIns.subList(0, votesAllowed)
+        if ((trialSize > messageSize) && trialContestData.writeIns.size > contestLimit) {
+            val truncateWriteIns = trialContestData.writeIns.subList(0, contestLimit)
                 .toMutableList()
             truncateWriteIns.add("*")
             trialContestData = trialContestData.copy(
@@ -90,7 +90,7 @@ data class ContestData(
 
         // chop write-in vote strings
         if ((trialSize > messageSize) && trialContestData.writeIns.isNotEmpty()) {
-            val chop = max(CHOP_WRITE_INS, (messageSize - trialSize + votesAllowed - 1) / votesAllowed)
+            val chop = max(CHOP_WRITE_INS, (messageSize - trialSize + contestLimit - 1) / contestLimit)
             val truncateWriteIns = trialContestData.writeIns.map {
                 if (it.length <= CHOP_WRITE_INS) it else it.substring(0, chop) + "*"
             }
@@ -101,8 +101,8 @@ data class ContestData(
         }
 
         // chop overvote list
-        while (trialSize > messageSize && (trialContestData.overvotes.size > votesAllowed + 1)) {
-            val chopList = trialContestData.overvotes.subList(0, votesAllowed + 1) + (-1)
+        while (trialSize > messageSize && (trialContestData.overvotes.size > contestLimit + 1)) {
+            val chopList = trialContestData.overvotes.subList(0, contestLimit + 1) + (-1)
             trialContestData = trialContestData.copy(overvotes = chopList)
             trialContestDataBA = trialContestData.publish().encodeToByteArray()
             trialSize = trialContestDataBA.size

--- a/egklib/src/commonMain/kotlin/electionguard/ballot/EncryptedBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/ballot/EncryptedBallot.kt
@@ -63,7 +63,7 @@ data class EncryptedBallot(
     data class Contest(
         override val contestId: String, // matches ContestDescription.contestIdd
         override val sequenceOrder: Int, // matches ContestDescription.sequenceOrder
-        val votesAllowed: Int, // matches ContestDescription.votesAllowed
+        val votesAllowed: Int, // matches ContestDescription.votesAllowed TODO remove
         val contestHash: UInt256, // eq 58
         override val selections: List<Selection>,
         val proof: ChaumPedersenRangeProofKnownNonce,

--- a/egklib/src/commonMain/kotlin/electionguard/ballot/Manifest.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/ballot/Manifest.kt
@@ -43,13 +43,23 @@ data class Manifest(
     }
 
     override fun contestLimit(contestId : String) : Int {
-        return contestIdToLimit[contestId]!!
+        return contestIdToContestLimit[contestId]!!
     }
 
-    /** Map of contestId to contest limit. */
-    val contestIdToLimit : Map<String, Int> by
+    override fun optionLimit(contestId : String) : Int {
+        return contestIdToOptionLimit[contestId]!!
+    }
+
+    /** Map of contestId to contest selection limit. */
+    val contestIdToContestLimit : Map<String, Int> by
     lazy {
-        contests.associate { it.contestId to it.votesAllowed}
+        contests.associate { it.contestId to it.votesAllowed }
+    }
+
+    /** Map of contestId to contest selection limit. */
+    val contestIdToOptionLimit : Map<String, Int> by
+    lazy {
+        contests.associate { it.contestId to it.optionSelectionLimit }
     }
 
     /** Map "$contestId/$selectionId" to candidateId. */
@@ -356,11 +366,12 @@ data class Manifest(
         val geopoliticalUnitId: String,
         val voteVariation: VoteVariationType,
         val numberElected: Int,
-        override val votesAllowed: Int,
+        val votesAllowed: Int, // contest selection limit = L, rename next breaking change
         val name: String,
         override val selections: List<SelectionDescription>,
         val ballotTitle: String?,
         val ballotSubtitle: String?,
+        val optionSelectionLimit : Int = 1, // option selection limit = R, spec 2.0 p 17.
     ) : ManifestIF.Contest
 
     /**

--- a/egklib/src/commonMain/kotlin/electionguard/ballot/ManifestIF.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/ballot/ManifestIF.kt
@@ -7,7 +7,6 @@ interface ManifestIF {
     interface Contest {
         val contestId: String
         val sequenceOrder: Int
-        val votesAllowed: Int
         val selections: List<Selection>
     }
 
@@ -19,7 +18,10 @@ interface ManifestIF {
     /** get the list of valid contests for the given ballotStyle */
     fun contestsForBallotStyle(ballotStyle : String): List<Contest>
 
-    /** get the contest limit (aka votesAllowed) for the given contest id */
+    /** get the contest selection limit (aka votesAllowed) for the given contest id */
     fun contestLimit(contestId : String): Int
+
+    /** get the option selection limit for the given contest id */
+    fun optionLimit(contestId : String): Int
 
 }

--- a/egklib/src/commonMain/kotlin/electionguard/encrypt/CiphertextBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/encrypt/CiphertextBallot.kt
@@ -18,7 +18,7 @@ data class CiphertextBallot(
     data class Contest(
         val contestId: String, // matches ContestDescription.contestIdd
         val sequenceOrder: Int, // matches ContestDescription.sequenceOrder
-        val votesAllowed: Int,
+        val votesAllowed: Int, // TODO remove
         val contestHash: UInt256, // eq 57
         val selections: List<Selection>,
         val proof: ChaumPedersenRangeProofKnownNonce,
@@ -60,7 +60,7 @@ fun CiphertextBallot.Contest.submit(): EncryptedBallot.Contest {
     return EncryptedBallot.Contest(
         this.contestId,
         this.sequenceOrder,
-        this.votesAllowed,
+        this.votesAllowed, // TODO remove
         this.contestHash,
         this.selections.map { it.submit() },
         this.proof,

--- a/egklib/src/commonMain/kotlin/electionguard/input/BallotInputValidation.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/input/BallotInputValidation.kt
@@ -106,14 +106,15 @@ class BallotInputValidation(val manifest: Manifest) {
                     logger.warn { msg }
                 }
 
-                // Vote can only be a 0 or 1, not supporting ranked choice, approval yet.
+                /* Vote can only be a 0 or 1, not supporting ranked choice, approval yet.
                 if (selection.vote < 0 || selection.vote > 1) {
-                    val msg = "Ballot.C.1 Ballot Selection '${selection.selectionId}' vote ($selection.vote) must be 0 or 1"
+                    val msg = "Ballot.C.1 Ballot Selection '${selection.selectionId}' vote (${selection.vote}) must be " +
+                            "between 0 and the contest.option_limit= ${electionContest.optionLimit}"
                     contestMesses.add(msg)
                     logger.warn { msg }
                 } else {
                     total += selection.vote
-                }
+                } */
             }
         }
 
@@ -128,11 +129,12 @@ class BallotInputValidation(val manifest: Manifest) {
          */
     }
 
-    class ElectionContest internal constructor(electionContest: Manifest.ContestDescription) {
-        val contestId = electionContest.contestId
-        val sequenceOrder = electionContest.sequenceOrder
-        val geopoliticalUnitId = electionContest.geopoliticalUnitId
-        val allowed = electionContest.votesAllowed
-        val selectionMap = electionContest.selections.associateBy { it.selectionId }
+    class ElectionContest internal constructor(contest: Manifest.ContestDescription) {
+        val contestId = contest.contestId
+        val sequenceOrder = contest.sequenceOrder
+        val geopoliticalUnitId = contest.geopoliticalUnitId
+        val selectionMap = contest.selections.associateBy { it.selectionId }
+        val contestLimit = contest.votesAllowed
+        val optionLimit = contest.optionSelectionLimit
     }
 }

--- a/egklib/src/commonMain/kotlin/electionguard/input/ManifestInputValidation.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/input/ManifestInputValidation.kt
@@ -114,13 +114,13 @@ class ManifestInputValidation(val manifest: Manifest) {
 
         when (contest.voteVariation) {
             one_of_m -> if (contest.votesAllowed != 1) {
-                val msg = "Manifest.C.2 one_of_m Contest votesAllowed (${contest.votesAllowed}) must be 1"
+                val msg = "Manifest.C.2 one_of_m Contest contest_limit (${contest.votesAllowed}) must be 1"
                 contestMesses.add(msg)
                 logger.warn { msg }
             }
             n_of_m -> {
                 if (contest.votesAllowed > contest.selections.size) {
-                    val msg = "Manifest.C.3 n_of_m Contest votesAllowed (${contest.votesAllowed}) must be <= selections" +
+                    val msg = "Manifest.C.3 n_of_m Contest contest_limit (${contest.votesAllowed}) must be <= selections" +
                             " (${contest.selections.size})"
                     contestMesses.add(msg)
                     logger.warn { msg }
@@ -128,7 +128,7 @@ class ManifestInputValidation(val manifest: Manifest) {
             }
             approval -> {
                 if (contest.votesAllowed != contest.selections.size) {
-                    val msg = "Manifest.C.4 approval Contest votesAllowed (${contest.votesAllowed}) must equal " +
+                    val msg = "Manifest.C.4 approval Contest contest_limit (${contest.votesAllowed}) must equal " +
                             "number of selections (${contest.selections.size})"
                     contestMesses.add(msg)
                     logger.warn { msg }
@@ -136,6 +136,19 @@ class ManifestInputValidation(val manifest: Manifest) {
             }
             else -> {}
         }
+
+        if (contest.votesAllowed < 1) {
+            val msg = "Manifest.C.5 Contest contest_limit (${contest.votesAllowed}) must be > 0"
+            contestMesses.add(msg)
+            logger.warn { msg }
+        }
+
+        if (contest.optionSelectionLimit < 1 || contest.optionSelectionLimit > contest.votesAllowed) {
+            val msg = "Manifest.C.6 contest option_limit (${contest.optionSelectionLimit}) must be > 0 and <= contest_limit (${contest.votesAllowed})"
+            contestMesses.add(msg)
+            logger.warn { msg }
+        }
+
         validateContestSelections(contest, contestMesses)
     }
 
@@ -190,7 +203,7 @@ class ManifestInputValidation(val manifest: Manifest) {
         }
     }
 
-    // there will be one encryption for each selection and one for each contest for the ContestData
+    // there will be one encryption for each selection and one for each contest (for the ContestData)
     private fun Manifest.ContestDescription.countEncryptions() = this.selections.size + 1
 
 }

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptedBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptedBallot.kt
@@ -30,7 +30,7 @@ data class PreEncryptedBallot(
 data class PreEncryptedContest(
     val contestId: String, // could just pass the manifest contest, in case other info is needed
     val sequenceOrder: Int,
-    val votesAllowed: Int,
+    val votesAllowed: Int, // TODO remove
     val selections: List<PreEncryptedSelection>, // nselections + limit, in sequenceOrder, eq 92,93
     val preencryptionHash: UInt256, // eq 95
 )

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/Recorder.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/Recorder.kt
@@ -93,7 +93,7 @@ class Recorder(
 
         val proof = ciphertextAccumulation.makeChaumPedersen(
             totalVotes,      // (ℓ in the spec)
-            preeContest.votesAllowed,  // (L in the spec)
+            preeContest.votesAllowed,  // (L in the spec) TODO remove ?
             aggNonce,
             publicKeyEG,
             extendedBaseHash,

--- a/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyDecryption.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyDecryption.kt
@@ -48,6 +48,8 @@ class VerifyDecryption(
                 results.add(Err("    10.B,13.D Ballot contains contest not in manifest: '$where' "))
                 continue
             }
+            val optionLimit = manifest.optionLimit(contest.contestId)
+            val contestLimit = manifest.contestLimit(contest.contestId)
 
             if (contest.decryptedContestData != null) {
                 verifyContestData(where, contest.decryptedContestData)
@@ -82,17 +84,14 @@ class VerifyDecryption(
                     results.add(Err("    10.A,13.A Tally Decryption M = K^t mod p failed: '$where2'"))
                 }
 
-                // TODO Issue #337
-                if (isBallot && (selection.tally !in (0..1))) {
-                    results.add(Err("     13.B ballot vote ${selection.tally} must be a 0 or a 1: '$where2'"))
+                if (isBallot && (selection.tally !in (0..optionLimit))) {
+                    results.add(Err("     13.B ballot vote ${selection.tally} must be between 0..$optionLimit : '$where2'"))
                 }
                 contestVotes += selection.tally
             }
             if (isBallot) {
-                // TODO Issue #337
-                val limit = manifest.contestLimit(contest.contestId)
-                if (contestVotes !in (0..limit)) {
-                    results.add(Err("     13.C sum of votes ${contestVotes} in contest must be less than $limit: '$where'"))
+                if (contestVotes !in (0..contestLimit)) {
+                    results.add(Err("     13.C sum of votes ${contestVotes} in contest must be between 0..$contestLimit : '$where'"))
                 }
             }
             // println(" verify $nselections on ${if (isBallot) "ballot" else "tally"} ${decrypted.id}")

--- a/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyEncryptedBallots.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyEncryptedBallots.kt
@@ -86,7 +86,7 @@ class VerifyEncryptedBallots(
             nselections += contest.selections.size
 
             contest.selections.forEach {
-                results.add(verifySelection(where, it))
+                results.add(verifySelection(where, it, manifest.optionLimit(contest.contestId)))
             }
 
             // Verification 6 (Adherence to vote limits)
@@ -136,7 +136,7 @@ class VerifyEncryptedBallots(
     }
 
     // Verification 5 (Well-formedness of selection encryptions)
-    private fun verifySelection(where: String, selection: EncryptedBallot.Selection): Result<Boolean, String> {
+    private fun verifySelection(where: String, selection: EncryptedBallot.Selection, optionLimit : Int): Result<Boolean, String> {
         val errors = mutableListOf<Result<Boolean, String>>()
         val here = "${where}/${selection.selectionId}"
 
@@ -144,7 +144,7 @@ class VerifyEncryptedBallots(
             selection.encryptedVote,
             this.jointPublicKey,
             this.extendedBaseHash,
-            1, // TODO
+            optionLimit,
         )
         if (svalid is Err) {
             errors.add(Err("    5. ChaumPedersenProof validation failed for ${here}} = ${svalid.error} "))

--- a/egklib/src/commonTest/kotlin/electionguard/input/KotestBallotGenerators.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/input/KotestBallotGenerators.kt
@@ -170,7 +170,7 @@ object KotestBallotGenerators {
 
     fun humanName(): Arb<String> =
         Arb.pair(Arb.of(firstNames), Arb.of(lastNames))
-            .map { "${it.first} ${it.second}" }
+            .map { it : Pair<Any, Any> ->  "${it.first} ${it.second}" }
 
     fun email(): Arb<String> {
         return Arb.string(minSize = 1, maxSize = 10, Codepoint.alphanumeric())
@@ -238,7 +238,8 @@ object KotestBallotGenerators {
         val partyAbbrvs = (1..numParties).map { "P$it" }
 
         return Arb.list(Arb.triple(uuid(), url(), color()), numParties..numParties).map {
-            it.mapIndexed { i, (uuid, url, color) ->
+            it.mapIndexed { i, trip : Triple<String, String, String> ->
+                val (uuid, url, color) = trip
                 Manifest.Party(
                     partyId = uuid,
                     name = partyNames[i],

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/EncryptedBallotJsonV.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/EncryptedBallotJsonV.kt
@@ -91,12 +91,16 @@ class EncryptedBallotJsonManifestFacade(ballot : EncryptedBallotJsonV) : Manifes
     override fun contestLimit(contestId: String): Int {
         return contests.find{ it.contestId == contestId }!!.votesAllowed
     }
+    override fun optionLimit(contestId : String) : Int {
+        return contests.find{ it.contestId == contestId }!!.optionLimit
+    }
 
     class ContestFacade(
         override val contestId: String,
         override val sequenceOrder: Int,
         override val selections: List<ManifestIF.Selection>,
-        override val votesAllowed: Int = 1,
+        val votesAllowed: Int = 1,
+        val optionLimit: Int = 1,
     ) : ManifestIF.Contest
 
     class SelectionFacade(

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/PlaintextBallotJsonV.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/PlaintextBallotJsonV.kt
@@ -50,8 +50,8 @@ class PlaintextBallotJsonManifestFacade(ballot : PlaintextBallotJsonV) : Manifes
             ContestFacade(
                 bc.contest_id,
                 bc.sequence_order,
+                bc.selections.map { SelectionFacade(it.selection_id, it.sequence_order) },
                 bc.votes_allowed,
-                bc.selections.map { SelectionFacade(it.selection_id, it.sequence_order)}
             )
         }
     }
@@ -60,16 +60,21 @@ class PlaintextBallotJsonManifestFacade(ballot : PlaintextBallotJsonV) : Manifes
     override fun contestLimit(contestId: String): Int {
         return contests.find{ it.contestId == contestId }!!.votesAllowed
     }
+    override fun optionLimit(contestId : String) : Int {
+        return contests.find{ it.contestId == contestId }!!.optionLimit
+    }
 
     class ContestFacade(
         override val contestId: String,
         override val sequenceOrder: Int,
-        override val votesAllowed: Int,
         override val selections: List<ManifestIF.Selection>,
+        val votesAllowed: Int = 1,
+        val optionLimit: Int = 1,
     ) : ManifestIF.Contest
 
     class SelectionFacade(
         override val selectionId: String,
-        override val sequenceOrder: Int) : ManifestIF.Selection
+        override val sequenceOrder: Int
+    ) : ManifestIF.Selection
 
 }


### PR DESCRIPTION
Issue#337

Rename votesAllowed -> contestLimit.
Remove votesAllowed from ManifestIF, use contestLimit(), optionLimit(). Add Manifest validate C.5, C.6.
Fix KotestBallotGenerators compile warnings.