### PR TITLE
Make PepVerify, TestPepWorkflow multi-threaded.

### DIFF
--- a/docs/CommandLineInterface.md
+++ b/docs/CommandLineInterface.md
@@ -14,6 +14,7 @@ last update 11/07/2023
   * [Run trusted Tally Decryption](#run-trusted-tally-decryption)
   * [Run trusted Ballot Decryption](#run-trusted-ballot-decryption)
   * [Run Verifier](#run-verifier)
+  * [Encrypt plaintext files again for Pep](#encrypt-plaintext-files-again-for-pep)
   * [Run Trusted Pep](#run-trusted-pep)
   * [Run Verify Pep](#run-verify-pep)
 <!-- TOC -->
@@ -307,6 +308,22 @@ Example:
     --showTime
 ````
 
+## Encrypt plaintext files again for Pep
+
+Example:
+
+````
+/usr/lib/jvm/jdk-19/bin/java \
+  -classpath egklib/egklib-all.jar \
+  electionguard.cli.RunBatchEncryption \
+    -in egklib/src/commonTest/data/workflow/allAvailableJson \
+    -ballots egklib/src/commonTest/data/workflow/allAvailableJson/private_data/input \
+    -out testOut/pep/testPepAllJson \
+    -device scanned \
+    --cleanOutput
+
+````
+
 ## Run Trusted Pep
 
 ```` 
@@ -327,11 +344,11 @@ Example:
 /usr/lib/jvm/jdk-19/bin/java \
   -classpath egklib/egklib-all.jar \
   electionguard.cli.RunTrustedPep \
-    -in testOut/cliWorkflow/electionRecord \
-    -trustees src/commonTest/data/workflow/allAvailableJson/private_data/trustees \
-    -scanned testOut/pep/testPepSomeJson/encrypted_ballots/scanned/
+    -in egklib/src/commonTest/data/workflow/allAvailableJson \
+    -trustees egklib/src/commonTest/data/workflow/allAvailableJson/private_data/trustees \
+    -scanned testOut/pep/testPepAllJson/encrypted_ballots/scanned \
     -out testOut/pep/testPepAllJson \
-    -nthreads 4 
+    -nthreads 25 
 ````
 
 ## Run Verify Pep
@@ -341,6 +358,7 @@ Usage: RunVerifyPep options_list
 Options: 
     --inputDir, -in -> Directory containing input election record (always required) { String }
     --pepDirectory, -pep -> Directory containing PEP output (always required) { String }
+    --nthreads, -nthreads [11] -> Number of parallel threads to use { Int }
     --help, -h -> Usage info 
 ````
 
@@ -350,6 +368,6 @@ Example:
 /usr/lib/jvm/jdk-19/bin/java \
   -classpath egklib/egklib-all.jar \
   electionguard.cli.RunVerifyPep \
-    -in testOut/cliWorkflow/electionRecord \
+    -in egklib/src/commonTest/data/workflow/allAvailableJson \
     -pep testOut/pep/testPepAllJson
 ````

--- a/egklib/src/commonMain/kotlin/electionguard/publish/Consumer.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/publish/Consumer.kt
@@ -33,12 +33,12 @@ interface Consumer {
     fun iterateDecryptedBallots(): Iterable<DecryptedTallyOrBallot>
     fun iteratePepBallots(pepDir : String): Iterable<BallotPep>
 
-    //// not part of the election record, private data
-    // read plaintext ballots in given directory, with filter
+    //// not part of the election record
+    // read plaintext ballots in given directory, private data.
     fun iteratePlaintextBallots(ballotDir: String, filter : ((PlaintextBallot) -> Boolean)? ): Iterable<PlaintextBallot>
-    // trustee in given directory for given guardianId
+    // trustee in given directory for given guardianId, private data.
     fun readTrustee(trusteeDir: String, guardianId: String): DecryptingTrusteeIF
-
+    // read specific file containing encrypted ballot (eg for PEP).
     fun readEncryptedBallot(ballotDir: String, ballotId: String) : Result<EncryptedBallot, String>
 }
 

--- a/egklib/src/jvmMain/kotlin/electionguard/cli/RunBatchEncryption.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/cli/RunBatchEncryption.kt
@@ -250,7 +250,7 @@ class RunBatchEncryption {
             println("Encryption with nthreads = $nthreads took $took millisecs for $count ballots = $msecsPerBallot msecs/ballot")
             val msecPerEncryption = (took.toDouble() / countEncryptions)
             val encryptionPerBallot = if (count == 0) 0 else (countEncryptions / count)
-            println("    $countEncryptions total encryptions = $encryptionPerBallot per ballot = $msecPerEncryption millisecs/encryption")
+            println("    $countEncryptions total encryptions = $encryptionPerBallot per ballot = $msecPerEncryption millisecs/encryption with $nthreads threads")
         }
 
         private var codeBaux = ByteArray(0)

--- a/egklib/src/jvmMain/kotlin/electionguard/cli/RunCreateElectionConfig.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/cli/RunCreateElectionConfig.kt
@@ -61,7 +61,7 @@ class RunCreateElectionConfig {
                         "   quorum= $quorum\n" +
                         "   output = $outputDir\n" +
                         "   createdBy = $createdBy\n" +
-                        "   baux0 = $baux0" +
+                        "   baux0 = $baux0\n" +
                         "   chainCodes = $chainCodes"
             )
 

--- a/egklib/src/jvmMain/kotlin/electionguard/cli/RunVerifier.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/cli/RunVerifier.kt
@@ -31,7 +31,7 @@ class RunVerifier {
                 ArgType.Int,
                 shortName = "nthreads",
                 description = "Number of parallel threads to use"
-            )
+            ).default(11)
             val showTime by parser.option(
                 ArgType.Boolean,
                 shortName = "time",
@@ -40,7 +40,7 @@ class RunVerifier {
             parser.parse(args)
             println("RunVerifier starting\n   input= $inputDir")
 
-            runVerifier(productionGroup(), inputDir, nthreads ?: 11, showTime)
+            runVerifier(productionGroup(), inputDir, nthreads, showTime)
         }
 
         fun runVerifier(group: GroupContext, inputDir: String, nthreads: Int, showTime: Boolean = false): Boolean {

--- a/egklib/src/jvmMain/kotlin/electionguard/cli/RunVerifyPep.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/cli/RunVerifyPep.kt
@@ -1,16 +1,22 @@
 package electionguard.cli
 
 import electionguard.core.*
-import electionguard.pep.VerifierPep
-import electionguard.publish.makeConsumer
-import electionguard.publish.readElectionRecord
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.required
 
 import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.unwrap
+import electionguard.pep.*
+import electionguard.publish.*
+import kotlinx.cli.default
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import mu.KotlinLogging
+import java.util.concurrent.atomic.AtomicInteger
+
+private val logger = KotlinLogging.logger("RunVerifyPep")
 
 /**
  * Run election record verification CLI.
@@ -26,7 +32,7 @@ class RunVerifyPep {
                 shortName = "in",
                 description = "Directory containing input election record"
             ).required()
-            val pepDirectory by parser.option(
+            val pepBallotDir by parser.option(
                 ArgType.String,
                 shortName = "pep",
                 description = "Directory containing PEP output"
@@ -35,14 +41,15 @@ class RunVerifyPep {
                 ArgType.Int,
                 shortName = "nthreads",
                 description = "Number of parallel threads to use"
-            )
+            ).default(11)
             parser.parse(args)
             println("RunVerifyPep starting\n   input= $inputDir")
 
-            runVerifyPep(productionGroup(), inputDir, pepDirectory, nthreads ?: 11)
+            // runVerifyPep(productionGroup(), inputDir, pepBallotDir, nthreads ?: 11)
+            batchVerifyPep(productionGroup(), inputDir, pepBallotDir, nthreads)
         }
 
-        fun runVerifyPep(group: GroupContext, inputDir: String, pepDirectory : String, nthreads: Int): Boolean {
+        fun runVerifyPep(group: GroupContext, inputDir: String, pepBallotDir: String, nthreads: Int): Boolean {
             val starting = getSystemTimeInMillis()
 
             val consumer = makeConsumer(group, inputDir)
@@ -51,7 +58,7 @@ class RunVerifyPep {
 
             var count = 0
             var allOk = true
-            consumer.iteratePepBallots(pepDirectory).forEach { ballotPEP ->
+            consumer.iteratePepBallots(pepBallotDir).forEach { ballotPEP ->
                 //     fun verify(ballotPEP: BallotPep): Result<Boolean, String> {
                 val result = verifier.verify(ballotPEP)
                 if (result is Err) {
@@ -66,6 +73,75 @@ class RunVerifyPep {
             val tookAll = (getSystemTimeInMillis() - starting)
             println("RunVerifier = $allOk took $tookAll msecs for $count ballots; allOk = ${allOk}")
             return allOk
+        }
+
+        fun batchVerifyPep(
+            group: GroupContext,
+            inputDir: String,
+            pepBallotDir: String,
+            nthreads: Int,
+        ) {
+            println(" Pep verify ballots in '${pepBallotDir}'")
+            val starting = getSystemTimeInMillis() // wall clock
+
+            val consumer = makeConsumer(group, inputDir)
+            val record = readElectionRecord(consumer)
+
+            val verifier = VerifierPep(group, record.extendedBaseHash()!!, ElGamalPublicKey(record.jointPublicKey()!!))
+
+            runBlocking {
+                val pepJobs = mutableListOf<Job>()
+                val ballotProducer = produceBallots(consumer, pepBallotDir)
+                repeat(nthreads) {
+                    pepJobs.add(
+                        launchPepWorker(
+                            it,
+                            ballotProducer,
+                            verifier,
+                        )
+                    )
+                }
+
+                // wait for all jobs to be done, then close everything
+                joinAll(*pepJobs.toTypedArray())
+            }
+
+            val nverify = count.get()
+            val took = getSystemTimeInMillis() - starting
+            val msecsPerBallot = (took.toDouble() / 1000 / nverify).sigfig()
+            println("PepVerify took ${took / 1000} wallclock secs for $nverify ballots = $msecsPerBallot secs/ballot with $nthreads threads")
+        }
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private fun CoroutineScope.produceBallots(consumer: Consumer, pepBallotDir: String): ReceiveChannel<BallotPep> =
+            produce {
+                for (ballot in consumer.iteratePepBallots(pepBallotDir)) {
+                    send(ballot)
+                    yield()
+                }
+                channel.close()
+            }
+
+        val count = AtomicInteger(0)
+        private fun CoroutineScope.launchPepWorker(
+            id: Int,
+            input: ReceiveChannel<BallotPep>,
+            verifier: VerifierPep,
+        ) = launch(Dispatchers.Default) {
+
+            for (ballotPEP in input) {
+                val result = verifier.verify(ballotPEP)
+                if (result is Err) {
+                    logger.warn { " PEP failed to verify ballot ${ballotPEP.ballotId} because $result" }
+                } else {
+                    val verifyOk = result.unwrap()
+                    logger.info { " PEP verify ${ballotPEP.ballotId} is ${verifyOk}" }
+                    println(" PEP verify ${ballotPEP.ballotId} is ${verifyOk}")
+                    count.getAndIncrement()
+                    yield()
+                }
+            }
+            logger.debug { "Decryptor #$id done" }
         }
     }
 }

--- a/egklib/src/jvmMain/kotlin/electionguard/publish/ConsumerProto.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/publish/ConsumerProto.kt
@@ -150,7 +150,7 @@ actual class ConsumerProto actual constructor(val topDir: String, val groupConte
         private val group: GroupContext,
         private val filter: Predicate<EncryptedBallot>?,
     ) : AbstractIterator<EncryptedBallot>() {
-        val pathList = ballotDir.pathList()
+        val pathList = ballotDir.pathListNoDirs()
         var idx = 0
 
         override fun computeNext() {


### PR DESCRIPTION
Add logback configuration to library fatJar. Set default level to INFO. 
ConsumerJson.readEncryptedBallot(), readTrustee() check for file existence instead of throwing an exception. 
RunTrustedPep skips missing ballots in scan directory.