### PR TITLE
Modifications to EG Decryption.

### DIFF
--- a/egklib/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeDoerre.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeDoerre.kt
@@ -31,6 +31,9 @@ data class DecryptingTrusteeDoerre(
     ): List<PartialDecryption> {
         val results: MutableList<PartialDecryption> = mutableListOf()
         for (text: ElementModP in texts) {
+            if (!text.isValidResidue()) {
+                return emptyList()
+            }
             val u = group.randomElementModQ(2) // random value u in Zq
             val a = group.gPowP(u)  // (a,b) for the proof, spec 2.0.0, eq 69
             val b = text powP u

--- a/egklib/src/commonTest/kotlin/electionguard/pep/PepTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/pep/PepTest.kt
@@ -268,7 +268,7 @@ class PepTest {
         val nb = btrustees.size
         val nd = egkPep.decryptor.ndGuardians
         val nenc = 1
-        val expect = (8 + 8 * nd + 8 * nb) * nenc // we do run the verifier
+        val expect = (16 + 4 * nb + 5 * nd) * nenc // we do run the verifier
         println(" after doEgkPep ${group.showAndClearCountPowP()} expect = $expect")
 
         assertTrue(resultPep is Ok)


### PR DESCRIPTION
Guardian decryption must check if text.isValidResidue().
TallyDecryptor can use VerifierSelectionProof and skip the individual guardian proofs if proof is valid. 
PepBlindTrust can also use VerifierSelectionProof.