### PR TITLE
Eliminate Exceptions from encryption code

### DIFF
--- a/egklib/build.gradle.kts
+++ b/egklib/build.gradle.kts
@@ -13,8 +13,14 @@ version = "2.0.0-SNAPSHOT"
 
 kotlin {
     jvm {
-        compilations.all { kotlinOptions.jvmTarget = "1.8" }
-        //        withJava()
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.freeCompilerArgs = listOf(
+                "-Xexpect-actual-classes",
+                "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi,kotlinx.serialization.ExperimentalSerializationApi"
+            )
+        }
+
         testRuns["test"].executionTask
             .configure {
                 useJUnitPlatform()

--- a/egklib/src/commonMain/kotlin/electionguard/input/ManifestInputValidation.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/input/ManifestInputValidation.kt
@@ -10,8 +10,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val logger = KotlinLogging.logger("ManifestInputValidation")
 
 /**
- * Validate an election manifest, give human readable error information.
- * See [ElectionGuard Input Validation](https://github.com/danwallach/electionguard-kotlin-multiplatform/blob/main/docs/InputValidation.md)
+ * Validate an election manifest, return human readable error information.
+ * See [Input Validation](https://github.com/votingworks/electionguard-kotlin-multiplatform/blob/main/docs/InputValidation.md)
  */
 class ManifestInputValidation(val manifest: Manifest) {
     private val gpUnits: Set<String> = manifest.geopoliticalUnits.map { it.geopoliticalUnitId }.toSet()

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptor.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptor.kt
@@ -5,7 +5,7 @@ import electionguard.core.*
 
 /**
  * The crypto part of the "The Ballot Encrypting Tool"
- * The encrypting/decrypting primaryNonce is done external to this.
+ * The encrypting/decrypting of the primaryNonce is done external to this.
  */
 class PreEncryptor(
     val group: GroupContext,
@@ -26,8 +26,11 @@ class PreEncryptor(
         • for each contest, votesAllowed additional null selections vectors, and a contest hash
         • a confirmation code for the ballot
      */
-    internal fun preencrypt(ballotId: String, ballotStyleId: String, primaryNonce: UInt256,
-                            codeBaux : ByteArray = ByteArray(0)
+    internal fun preencrypt(
+        ballotId: String,
+        ballotStyleId: String,
+        primaryNonce: UInt256,
+        codeBaux : ByteArray = ByteArray(0)
     ): PreEncryptedBallot {
 
         val mcontests = manifest.contestsForBallotStyle(ballotStyleId)
@@ -61,7 +64,7 @@ class PreEncryptor(
         // In a contest with a selection limit of L, an additional L null vectors are added
         var sequence = this.selections.size
         for (nullVectorIdx in (1..contestLimit)) {
-            // TODO null labels may be in manifest, see 4.2.1
+            // TODO null labels may be in manifest, see 4.2.1. wtf?
             preeSelections.add( preencryptSelection(primaryNonce, this.sequenceOrder, "null${nullVectorIdx}", sequence, sortedSelectionIndices))
             sequence++
         }

--- a/egklib/src/commonTest/kotlin/electionguard/json2/ElectionConfigTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/json2/ElectionConfigTest.kt
@@ -1,16 +1,11 @@
 package electionguard.json2
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.getError
-import com.github.michaelbull.result.unwrap
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionConstants
 import electionguard.core.Base16.fromHex
 import electionguard.core.UInt256
 import electionguard.core.productionGroup
 import electionguard.util.ErrorMessages
-import io.kotest.assertions.throwables.shouldThrowUnitWithMessage
 import kotlin.test.*
 
 class ElectionConfigTest {

--- a/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorOutputTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorOutputTest.kt
@@ -76,9 +76,15 @@ internal class PreEncryptorOutputTest {
 
         // record
         val recorder = Recorder(group, manifest, publicKey, extendedBaseHash, "device", ::sigma)
-        val (recordedBallot, ciphertextBallot) = with(recorder) {
-            markedBallot.record(primaryNonce)
+        val errs = ErrorMessages("MarkedBallot ${markedBallot.ballotId}")
+        val pair = with(recorder) {
+            markedBallot.record(primaryNonce, errs)
         }
+        if (errs.hasErrors()) {
+            println(errs)
+            return
+        }
+        val (recordedBallot, ciphertextBallot) = pair!!
 
         // show record results
         if (show) {

--- a/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorTest.kt
@@ -24,6 +24,7 @@ import kotlin.math.min
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 private val random = Random
@@ -73,9 +74,11 @@ internal class PreEncryptorTest {
             val recorder =
                 Recorder(group, manifest, electionInit.jointPublicKey, electionInit.extendedBaseHash, "device", ::sigma)
 
+            val errs = ErrorMessages("MarkedBallot ${mballot.ballotId}")
             with(recorder) {
-                mballot.record(primaryNonce)
+                mballot.record(primaryNonce, errs)
             }
+            assertFalse(errs.hasErrors())
         }
     }
 
@@ -206,9 +209,12 @@ internal fun runComplete(
 
     // record
     val recorder = Recorder(group, manifest, publicKey, qbar, "device", ::sigma)
-    val (recordedBallot, ciphertextBallot) = with(recorder) {
-        markedBallot.record(primaryNonce)
+    val errs = ErrorMessages("MarkedBallot ${markedBallot.ballotId}")
+    val pair = with(recorder) {
+        markedBallot.record(primaryNonce, errs)
     }
+    assertFalse(errs.hasErrors())
+    val (recordedBallot, ciphertextBallot) = pair!!
 
     // show record results
     if (show) {

--- a/egklib/src/commonTest/kotlin/electionguard/workflow/TestNumGuardians.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/workflow/TestNumGuardians.kt
@@ -70,7 +70,7 @@ class TestNumGuardians {
         )
 
         // key ceremony
-        val (manifest, init) = runFakeKeyCeremony(group, workingDir, workingDir, trusteeDir, nguardians, quorum, false)
+        val (_, init) = runFakeKeyCeremony(group, workingDir, workingDir, trusteeDir, nguardians, quorum, false)
         println("FakeKeyCeremony created ElectionInitialized, guardians = $present")
         println("----------- after keyCeremony ${group.showAndClearCountPowP()}")
 

--- a/egklib/src/commonTest/kotlin/electionguard/workflow/TestPepWorkflow.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/workflow/TestPepWorkflow.kt
@@ -58,7 +58,7 @@ class TestPepWorkflow {
         )
 
         // key ceremony
-        val (manifest, init) = runFakeKeyCeremony(group, workingDir, workingDir, trusteeDir, nguardians, quorum, false)
+        val (_, init) = runFakeKeyCeremony(group, workingDir, workingDir, trusteeDir, nguardians, quorum, false)
 
         // encrypt
         group.showAndClearCountPowP()

--- a/egklib/src/jvmMain/kotlin/electionguard/cli/RunExampleEncryption.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/cli/RunExampleEncryption.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import electionguard.core.*
 import electionguard.encrypt.AddEncryptedBallot
+import electionguard.input.ManifestInputValidation
 import electionguard.input.RandomBallotProvider
 import electionguard.publish.makeConsumer
 import electionguard.publish.makePublisher
@@ -31,6 +32,10 @@ class RunExampleEncryption {
             }
             val electionInit = initResult.unwrap()
             val manifest = consumerIn.makeManifest(electionInit.config.manifestBytes)
+            val errors = ManifestInputValidation(manifest).validate()
+            if (ManifestInputValidation(manifest).validate().hasErrors()) {
+                throw RuntimeException("ManifestInputValidation error $errors")
+            }
 
             val publisher = makePublisher(outputDir, true, consumerIn.isJson())
             publisher.writeElectionInitialized(electionInit)

--- a/egklib/src/jvmTest/kotlin/electionguard/core/SimpleBallotBenchmark.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/core/SimpleBallotBenchmark.kt
@@ -16,7 +16,7 @@ class SimplePlaintextBallot(val selections: List<Int>)
 
 class SimpleEncryptedBallot(val selectionsAndProofs: List<Pair<ElGamalCiphertext, ChaumPedersenRangeProofKnownNonce>>, val sumProof: ChaumPedersenRangeProofKnownNonce)
 
-fun SimplePlaintextBallot.encrypt(context: GroupContext, keypair: ElGamalKeypair, seed: ElementModQ, limit : Int = 1): SimpleEncryptedBallot {
+fun SimplePlaintextBallot.encrypt(keypair: ElGamalKeypair, seed: ElementModQ, limit : Int = 1): SimpleEncryptedBallot {
     val encryptionNonces = Nonces(seed, "encryption")
     val proofNonces = Nonces(seed, "proof")
     val plaintextWithNonce = selections.mapIndexed { i, s -> Pair(s, encryptionNonces[i]) }
@@ -59,9 +59,9 @@ fun main() {
     println("Ballot encryption simulation benchmark, JDK: ${System.getProperty("java.version")}")
 
     runBlocking {
-        ProductionMode.values()
+        ProductionMode.entries
             .forEach { mode ->
-                PowRadixOption.values().filter { it != PowRadixOption.EXTREME_MEMORY_USE }
+                PowRadixOption.entries.filter { it != PowRadixOption.EXTREME_MEMORY_USE }
                     .forEach { powRadixOption ->
                         println("=======================================================")
                         println("Initializing benchmark for $powRadixOption, $mode")
@@ -75,9 +75,8 @@ fun main() {
                         1.encrypt(keypair, nonces[0]).decrypt(keypair)
 
                         println("Running!")
-                        var results: List<SimpleEncryptedBallot>
                         val encryptionTimeMs = measureTimeMillis {
-                            results = ProgressBar
+                            ProgressBar
                                 .wrap(
                                     (0 until numBallots).asIterable().toList(),
                                     ProgressBarBuilder()
@@ -89,7 +88,7 @@ fun main() {
                                         .setMaxRenderedLength(100)
                                         .showSpeed()
                                 )
-                                .map { ballots[it].encrypt(context, keypair, nonces[it]) }
+                                .map { ballots[it].encrypt(keypair, nonces[it]) }
                         }
                         val encryptionTime = encryptionTimeMs / 1000.0
 

--- a/egklib/src/jvmTest/kotlin/electionguard/json/PrimesTest.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/json/PrimesTest.kt
@@ -40,7 +40,7 @@ class PrimesTest {
 
         val rnn = Primes4096.residualNotNormalized
         println("rnn in base64 = ${rnn.toBase64()}")
-        val rnnelem = ProductionElementModP(rnn.toBigInteger(), group as ProductionGroupContext)
+        val rnnelem = ProductionElementModP(rnn.toBigInteger(), group)
         println("rnn == r as bigInt ${r.toBigInteger() == rnn.toBigInteger()}")
         println("rnn == r as ElementModP ${relem == rnnelem}")
 
@@ -49,7 +49,7 @@ class PrimesTest {
         val q = Primes4096.smallPrimeBytes.toBigInteger()
         val cr = (p - BigInteger.ONE) / q
         println("computed r in base64 = ${cr.toByteArray().toBase64()}")
-        val crelem = ProductionElementModP(cr, group as ProductionGroupContext)
+        val crelem = ProductionElementModP(cr, group)
         println("cr == r as bigInt ${r.toBigInteger() == cr}")
         println("cr == r as ElementModP ${relem == crelem}")
 
@@ -63,7 +63,7 @@ class PrimesTest {
         val ba2 = ba.normalize(nbytes)
         val rsb = ba2.toBigInteger()
         println("rs == r as bigInt ${r.toBigInteger() == rsb}")
-        val rsbelem = ProductionElementModP(rsb, group as ProductionGroupContext)
+        val rsbelem = ProductionElementModP(rsb, group)
         println("rs == r as ElementModP ${relem == rsbelem}")
         assertEquals(relem, rsbelem)
     }

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/BallotEncryptionTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/BallotEncryptionTestVector.kt
@@ -196,7 +196,6 @@ class BallotEncryptionTestVector {
             val plainContest: PlaintextContestJsonV = pair.first
             val expectContest: EncryptedContestJson = pair.second
 
-            val limit = expectContest.expected_proof.proofs.size
             val randomUj = expectContest.expected_proof.proofs.map { it.u_nonce.import(group) ?: throw IllegalArgumentException("readBallotEncryptionTestVector malformed u_nonce") }
             val randomCj = expectContest.expected_proof.proofs.map { it.c_nonce.import(group) ?: throw IllegalArgumentException("readBallotEncryptionTestVector malformed c_nonce") }
 
@@ -221,20 +220,19 @@ class BallotEncryptionTestVector {
                 val plainSelection: PlaintextSelectionJsonV = pair2.first
                 val expectSelection: EncryptedSelectionJson = pair2.second
 
-                val limit = expectSelection.expected_proof.proofs.size
-                val randomUj = expectSelection.expected_proof.proofs.map { it.u_nonce.import(group) ?: throw IllegalArgumentException("readBallotEncryptionTestVector malformed u_nonce") }
-                val randomCj = expectSelection.expected_proof.proofs.map { it.c_nonce.import(group) ?: throw IllegalArgumentException("readBallotEncryptionTestVector malformed u_nonce") }
+                val randomUjSel = expectSelection.expected_proof.proofs.map { it.u_nonce.import(group) ?: throw IllegalArgumentException("readBallotEncryptionTestVector malformed u_nonce") }
+                val randomCjSel = expectSelection.expected_proof.proofs.map { it.c_nonce.import(group) ?: throw IllegalArgumentException("readBallotEncryptionTestVector malformed u_nonce") }
 
-                val proofWithNonces: ChaumPedersenRangeProofKnownNonce = actualSelection.ciphertext.makeChaumPedersenWithNonces(
+                val proofWithNoncesSel: ChaumPedersenRangeProofKnownNonce = actualSelection.ciphertext.makeChaumPedersenWithNonces(
                     plainSelection.vote,
                     actualSelection.selectionNonce, // encryption nonce ξ for which (α, β) is an encryption of ℓ.
                     publicKey,
                     extendedBaseHash,
-                    randomUj,
-                    randomCj
+                    randomUjSel,
+                    randomCjSel
                 )
 
-                assertEquals(expectSelection.expected_proof.import(group), proofWithNonces)
+                assertEquals(expectSelection.expected_proof.import(group), proofWithNoncesSel)
             }
 
         }

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/PreEncryptionRecordedTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/PreEncryptionRecordedTestVector.kt
@@ -27,6 +27,7 @@ import kotlin.io.use
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 /** Generate the election record information from a Pre-encrypted Ballot that has been voted. */
 class PreEncryptionRecordedTestVector {
@@ -83,9 +84,12 @@ class PreEncryptionRecordedTestVector {
 
         // record
         val recorder = Recorder(group, manifest, publicKey, extendedBaseHash, "device", ::sigma)
-        val (recordedBallot, ciphertextBallot) = with(recorder) {
-            markedBallot.record(primaryNonce)
+        val errs = ErrorMessages("MarkedBallot ${markedBallot.ballotId}")
+        val pair = with(recorder) {
+            markedBallot.record(primaryNonce, errs)
         }
+        assertFalse(errs.hasErrors())
+        val (recordedBallot, ciphertextBallot) = pair!!
 
         // roundtrip through the proto, combines the recordedBallot
         val encryptedBallot = ciphertextBallot.cast()
@@ -131,9 +135,12 @@ class PreEncryptionRecordedTestVector {
 
         // record
         val recorder = Recorder(group, manifest, publicKey, extendedBaseHash, "device", ::sigma)
-        val (recordedBallot, ciphertextBallot) = with(recorder) {
-            markedBallot.record(primaryNonce)
+        val errs = ErrorMessages("MarkedBallot ${markedBallot.ballotId}")
+        val pair = with(recorder) {
+            markedBallot.record(primaryNonce, errs)
         }
+        assertFalse(errs.hasErrors())
+        val (recordedBallot, ciphertextBallot) = pair!!
 
         // roundtrip through the proto, combines the recordedBallot
         val encryptedBallot = ciphertextBallot.cast()


### PR DESCRIPTION
Eliminate Exceptions (mostly) from pre-encryption code.
ElectionRecordFactory.readElectionRecord validates the manifest, so AddEncryptedBallot doesnt have to.
AddEncryptedBallot uses the confirmationCode to track the pending ballots, so cant get an Exception on ccode.toHex().
Set opt-in compiler flags to reduce compiler noise