### PR TITLE
Cleanup Group and GroupCommon

### DIFF
--- a/egklib/build.gradle.kts
+++ b/egklib/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "electionguard-kotlin-multiplatform"
-version = "2.0.3-SNAPSHOT"
+version = "2.0.4-SNAPSHOT"
 
 kotlin {
     jvm {

--- a/egklib/src/commonMain/kotlin/electionguard/core/Base16.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Base16.kt
@@ -1,5 +1,6 @@
 package electionguard.core
 
+import electionguard.core.Base16.fromHex
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
@@ -88,5 +89,11 @@ object Base16 {
      */
     fun String.fromHexSafe(): ByteArray =
         fromHex() ?: throw IllegalArgumentException("fromHexSafe invalid input= '$this'")
-
 }
+
+/**
+ * Converts a base-16 (hexadecimal) string to an [ElementModP]. Returns null if the number is out of
+ * bounds or the string is malformed.
+ */
+fun GroupContext.base16ToElementModP(s: String): ElementModP? =
+    s.fromHex()?.let { binaryToElementModP(it) }

--- a/egklib/src/commonMain/kotlin/electionguard/core/Base64.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Base64.kt
@@ -104,8 +104,7 @@ object Base64 {
 
         /**
          * Encodes all bytes from the specified byte array into a newly-allocated byte array using
-         * the [Base64] encoding scheme. The returned byte array is of the length of the resulting
-         * bytes.
+         * the [Base64] encoding scheme. The returned byte array is of the length of the resulting bytes.
          *
          * @param src the byte array to encode
          * @param useBase64URL use Base64URL else use Base64

--- a/egklib/src/commonMain/kotlin/electionguard/core/ElGamalCiphertext.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/ElGamalCiphertext.kt
@@ -89,6 +89,7 @@ fun List<ElGamalCiphertext>.add(other: List<ElGamalCiphertext>): List<ElGamalCip
     return result
 }
 
+// TODO what happens if nonce is small enough to take the log of?
 fun Int.encrypt(
     keypair: ElGamalKeypair,
     nonce: ElementModQ = keypair.context.randomElementModQ(minimum = 1)

--- a/egklib/src/commonMain/kotlin/electionguard/core/ElGamalKeys.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/ElGamalKeys.kt
@@ -58,7 +58,7 @@ class ElGamalPublicKey(inputKey: ElementModP) {
 
 /**
  * A wrapper around an ElementModQ that allows us to hang onto a pre-computed [negativeKey]
- * (i.e., the additive inverse mod `q`). The secret key must be in [2, Q).
+ * (i.e., the additive inverse mod q). The secret key must be in [2, Q).
  */
 class ElGamalSecretKey(val key: ElementModQ) {
     init {

--- a/egklib/src/commonMain/kotlin/electionguard/core/Utils.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Utils.kt
@@ -106,8 +106,7 @@ fun <T : Any> List<T?>.noNullValuesOrNull(): List<T>? {
 
 /**
  * Normally, Kotlin's `Enum.valueOf` or [enumValueOf] method will throw an exception for an invalid
- * input. This method will instead return `null` if the string doesn't map to a valid value of the
- * enum.
+ * input. This method will instead return `null` if the string doesn't map to a valid value of the enum.
  */
 inline fun <reified T : Enum<T>> safeEnumValueOf(name: String?): T? {
     if (name == null) {

--- a/egklib/src/commonMain/kotlin/electionguard/json/GuardianJsonR.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/json/GuardianJsonR.kt
@@ -43,7 +43,7 @@ fun GuardianJsonR.import(group: GroupContext, errs : ErrorMessages) : GuardianR?
 fun GuardianR.convert(group: GroupContext) = Guardian(
     this.name,
     this.i,
-    //     Schnorr proof is missing - fake it
+    //     Schnorr proof is missing - fake it TODO WTF?
     this.coefficient_commitments.map { SchnorrProof(it, group.ONE_MOD_Q, group.TWO_MOD_Q) }
 )
 

--- a/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyTally.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyTally.kt
@@ -39,12 +39,12 @@ class VerifyTally(
                     if (selection.encryptedVote.data != accum.data) {
                         errs.add("  8.B  Ballot Aggregation does not match: $key")
                     }
-                } else {
+                } /* else {
                     // TODO what is it? is it needed? left over from placeholders ??
                     if (selection.encryptedVote.pad != group.ZERO_MOD_P || selection.encryptedVote.data != group.ZERO_MOD_P) {
                         errs.add("    Ballot Aggregation empty does not match $key")
                     }
-                }
+                } */
             }
         }
 

--- a/egklib/src/commonTest/kotlin/electionguard/core/HashTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/HashTest.kt
@@ -79,9 +79,9 @@ class HashTest {
         runTest {
             val group = productionGroup()
             val s1q = "C49A1E8053FBA95F6B7CD3F3B30B101CDD595C435A46AECF2872F47F1C601206".fromHexSafe()
-                .toUInt256safe().toElementModQ(group).base16()
+                .toUInt256safe().toElementModQ(group).toHex()
             val s2q = "000C49A1E8053FBA95F6B7CD3F3B30B101CDD595C435A46AECF2872F47F1C601206".fromHexSafe()
-                .toUInt256safe().toElementModQ(group).base16()
+                .toUInt256safe().toElementModQ(group).toHex()
             assertEquals(s1q, s2q)
             assertEquals(s1q.encodeToByteArray().size, s2q.encodeToByteArray().size)
             assertEquals(hashFunction(s1q.encodeToByteArray(), s1q), hashFunction(s2q.encodeToByteArray(), s2q))
@@ -94,7 +94,7 @@ class HashTest {
     fun testElementModQToHex() {
         runTest {
             val group = productionGroup()
-            val subject = group.TWO_MOD_Q.base16()
+            val subject = group.TWO_MOD_Q.toHex()
             println(" len = ${subject.length} hex = '${subject}'")
             assertEquals(64, subject.length)
         }

--- a/egklib/src/commonTest/kotlin/electionguard/core/PowRadixTiming.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/PowRadixTiming.kt
@@ -80,7 +80,7 @@ class PowRadixTiming {
         val nonces = List(n) { group.randomElementModQ() }
 
         var stopwatch = Stopwatch()
-        repeat(n) { require( !group.gPowP(nonces[it]).isZero()) }
+        repeat(n) { group.gPowP(nonces[it]) }
         var duration = stopwatch.stop()
         val peracc = duration.toDouble() / n / 1_000_000
         println("  ${count.pad(4)} acc $n = ${peracc.sigfig(3)} msec per acc")
@@ -102,14 +102,14 @@ class PowRadixTiming {
         val h = group.gPowP(group.randomElementModQ())
 
         var stopwatch = Stopwatch()
-        repeat(n) { require( !group.gPowP(nonces[it]).isZero()) }
+        repeat(n) { group.gPowP(nonces[it]) }
 
         var duration = stopwatch.stop()
         val peracc = duration.toDouble() / n / 1_000_000
         println(" acc took $duration msec for $n = $peracc msec per acc")
 
         stopwatch.start()
-        repeat(n) { require(!(h powP nonces[it]).isZero()) }
+        repeat(n) { h powP nonces[it] }
 
         duration = stopwatch.stop()
         val perexp = duration.toDouble() / n / 1_000_000
@@ -133,7 +133,7 @@ class PowRadixTiming {
         val elemps = nonces.map { group.gPowP(it) }
 
         var starting = getSystemTimeInMillis()
-        val prod = elemps.reduce { a, b -> a * b }
+        elemps.reduce { a, b -> a * b }
         var duration = getSystemTimeInMillis() - starting
         var peracc = duration.toDouble() / n
         println(" multiply took $duration msec for $n = $peracc msec per multiply")

--- a/egklib/src/commonTest/kotlin/electionguard/core/TestHelpers.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/TestHelpers.kt
@@ -72,7 +72,7 @@ fun generateUInt256(context: GroupContext): UInt256 {
     return generateElementModQ(context).toUInt256safe();
 }
 
-fun generateElementModP(context: GroupContext) = context.uIntToElementModP(Random.nextUInt(1879047647.toUInt()))
+fun generateElementModP(context: GroupContext) = context.randomElementModP()
 
 fun generatePublicKey(group: GroupContext): ElementModP =
     group.gPowP(group.randomElementModQ())

--- a/egklib/src/commonTest/kotlin/electionguard/core/UInt256Test.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/UInt256Test.kt
@@ -34,7 +34,7 @@ class UInt256Test {
             assertEquals(32, s1u.bytes.size)
 
             val s1q = s1u.toElementModQ(group)
-            assertEquals(64, s1q.base16().length)
+            assertEquals(64, s1q.toHex().length)
         }
     }
 }

--- a/egklib/src/commonTest/kotlin/electionguard/workflow/WorkflowEncryptDecryptTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/workflow/WorkflowEncryptDecryptTest.kt
@@ -9,7 +9,6 @@ import electionguard.core.elGamalKeyPairFromRandom
 import electionguard.core.encrypt
 import electionguard.core.encryptedSum
 import electionguard.core.productionGroup
-import electionguard.core.randomElementModQ
 import electionguard.core.runTest
 import electionguard.core.toElementModQ
 import kotlin.test.Test

--- a/egklib/src/jvmMain/kotlin/electionguard/util/StopWatch.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/util/StopWatch.kt
@@ -54,7 +54,7 @@ class Stopwatch(running: Boolean = true) {
         fun perRow(took: Long, nrows: Int): String {
             val tookMs = took / 1_000_000
             val perRow = tookMs.toDouble()  / nrows
-            return "took ${tookMs} ms for $nrows rows, ${perRow.sigfig(2)} ms per row"
+            return "took ${tookMs} ms for $nrows rows, ${perRow.sigfig(3)} ms per row"
         }
 
         // TODO units option
@@ -62,13 +62,13 @@ class Stopwatch(running: Boolean = true) {
             val ratio = num.toDouble() / den
             val numValue = num / 1_000_000
             val denValue = den / 1_000_000
-            return "$numValue / $denValue ms =  ${ratio.sigfig(2)}"
+            return "$numValue / $denValue ms =  ${ratio.sigfig(3)}"
         }
 
         fun perRow(num: Long, den: Long, nrows: Int): String {
             val numValue = num.toDouble() / nrows / 1_000_000
             val denValue = den.toDouble() / nrows / 1_000_000
-            return "${numValue.sigfig(2)} / ${denValue.sigfig(2)} ms per row"
+            return "${numValue.sigfig(2)} / ${denValue.sigfig(3)} ms per row"
         }
 
         fun ratioAndPer(num: Long, den: Long, nrows: Int): String {

--- a/egklib/src/jvmTest/kotlin/electionguard/core/ElementEqualityJvmTest.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/core/ElementEqualityJvmTest.kt
@@ -22,7 +22,7 @@ class ElementEqualityJvmTest {
         assertEquals(biu2.toString(), "UInt256(0xC59AAD302F149A018F925AEC7B819C6F890441F0954C36C198FD0066C5A93F11)")
 
         assertEquals(biu2, biu)
-        assertEquals(biq2.base16(), biq.base16())
+        assertEquals(biq2.toHex(), biq.toHex())
 
         // ElementModQ now equal because it uses normalized bytes
         assertNotEquals(bi2, bi)

--- a/egklib/src/jvmTest/kotlin/electionguard/core/TestSetMembership.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/core/TestSetMembership.kt
@@ -9,7 +9,13 @@ class TestSetMembership {
 
     @Test
     fun testSetMembershipZero() {
-        assertFalse(checkMembership(group.ZERO_MOD_P))
+        val zero = group.binaryToElementModP(ByteArray(11))!!
+        assertFalse(checkMembership(zero))
+    }
+
+    @Test
+    fun testSetMembershipOne() {
+        assertTrue(checkMembership(group.ONE_MOD_P))
     }
 
     @Test
@@ -21,7 +27,8 @@ class TestSetMembership {
 
     @Test
     fun testSetMembershiNotG() {
-        val checkit = group.TWO_MOD_P powP group.TWO_MOD_Q
+        val two = group.binaryToElementModP(ByteArray(1) { 2 })!!
+        val checkit = two powP group.TWO_MOD_Q
         assertFalse(checkMembership(checkit))
     }
 

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/BallotChainingTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/BallotChainingTestVector.kt
@@ -143,7 +143,7 @@ class BallotChainingTestVector {
                 jsonReader.decodeFromStream<BallotChainingTestVector>(inp)
             }
 
-        val publicKey = ElGamalPublicKey(group.base16ToElementModPsafe(testVector.joint_public_key))
+        val publicKey = ElGamalPublicKey(group.base16ToElementModP(testVector.joint_public_key)!!)
         val extendedBaseHash = UInt256(testVector.extended_base_hash.fromHexSafe())
         val configBaux0 : ByteArray = testVector.configBaux0
         val ballotsZipped = testVector.ballots.zip(testVector.expected_encrypted_ballots)

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/ConfirmationCodeTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/ConfirmationCodeTestVector.kt
@@ -130,7 +130,7 @@ class ConfirmationCodeTestVector {
                 jsonReader.decodeFromStream<ConfirmationCodeTestVector>(inp)
             }
 
-        val publicKey = ElGamalPublicKey(group.base16ToElementModPsafe(testVector.joint_public_key))
+        val publicKey = ElGamalPublicKey(group.base16ToElementModP(testVector.joint_public_key)!!)
         val extendedBaseHash = UInt256(testVector.extended_base_hash.fromHex()!!)
         val ballotsZipped = testVector.ballots.zip(testVector.expected_encrypted_ballots)
 

--- a/egkliball/build.gradle.kts
+++ b/egkliball/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    implementation(files("../egklib/build/libs/egklib-jvm-2.0.3-SNAPSHOT.jar")) // add the library to the fatJar
+    implementation(files("../egklib/build/libs/egklib-jvm-2.0.4-SNAPSHOT.jar")) // add the library to the fatJar
     implementation(libs.bundles.eglib)
     implementation(libs.logback.classic)
 }


### PR DESCRIPTION
Remove unused methods.
Remove ZERO_MOD_P, TWO_MOD_P, Q_MOD_P, uIntToElementModP().
Remove inBoundsNoZero(), q.powQ(), gPowPSmall(), isZero() is Q only.
version incremented to 2.04